### PR TITLE
Add `chronus version --ignore-policies`

### DIFF
--- a/.changeset/version-no-policy-2024-0-30-18-45-56.md
+++ b/.changeset/version-no-policy-2024-0-30-18-45-56.md
@@ -1,0 +1,5 @@
+---
+"@chronus/chronus": patch
+---
+
+Add `--ignore-policies` flag to `chronus version` command that allows ignoring the versioning policies.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         name: Build
 
       - run: pnpm run test
-        name: Build
+        name: Test
 
       - run: pnpm run check-format
         name: Check formatting

--- a/packages/chronus/src/cli/cli.ts
+++ b/packages/chronus/src/cli/cli.ts
@@ -23,7 +23,17 @@ async function main() {
     })
     .command("add", "Add a new changeset", () => addChangeset(process.cwd()))
     .command("verify", "Verify all packages changes have been documented", () => verifyChangeset(process.cwd()))
-    .command("version", "Apply change changeset and bump the versions", () => applyChangesets(process.cwd()))
+    .command(
+      "version",
+      "Apply change changeset and bump the versions",
+      (cmd) =>
+        cmd.option("ignore-policies", {
+          type: "boolean",
+          description: "Ignore versioning policies and bump each package independently",
+          default: false,
+        }),
+      (args) => applyChangesets(process.cwd(), { ignorePolicies: args.ignorePolicies }),
+    )
     .command("status", "Display the status of changes. What will happen during the next release", () =>
       showStatus(process.cwd()),
     )

--- a/packages/chronus/src/cli/commands/apply-changesets.ts
+++ b/packages/chronus/src/cli/commands/apply-changesets.ts
@@ -6,7 +6,10 @@ import { assembleReleasePlan } from "../../release-plan/assemble-release-plan.js
 import { NodechronusHost } from "../../utils/node-host.js";
 import { createPnpmWorkspaceManager } from "../../workspace-manager/pnpm.js";
 
-export async function applyChangesets(cwd: string): Promise<void> {
+export interface ApplyChangesetsOptions {
+  ignorePolicies?: boolean;
+}
+export async function applyChangesets(cwd: string, options?: ApplyChangesetsOptions): Promise<void> {
   const host = NodechronusHost;
   const pnpm = createPnpmWorkspaceManager(host);
   const workspace = await pnpm.load(cwd);
@@ -22,7 +25,7 @@ export async function applyChangesets(cwd: string): Promise<void> {
       }),
   );
 
-  const releasePlan = assembleReleasePlan(changesets, workspace, config);
+  const releasePlan = assembleReleasePlan(changesets, workspace, config, options);
 
   const changeSetReleasePlan: ChangesetReleasePlan = {
     changesets: releasePlan.changesets,

--- a/packages/chronus/src/release-plan/assemble-release-plan.test.ts
+++ b/packages/chronus/src/release-plan/assemble-release-plan.test.ts
@@ -95,5 +95,16 @@ describe("Assemble Release Plan", () => {
       expect(plan.actions[0]).toMatchObject({ packageName: "pkg-a", oldVersion: "1.0.0", newVersion: "1.1.0" });
       expect(plan.actions[1]).toMatchObject({ packageName: "pkg-b", oldVersion: "1.0.0", newVersion: "1.1.0" });
     });
+
+    it("ignore policy when options.ignorePolicies: true", () => {
+      const plan = assembleReleasePlan(
+        [makeChangeset("pkg-a", "patch"), makeChangeset("pkg-c", "patch")],
+        workspace,
+        lockStepConfig,
+      );
+      expect(plan.actions).toHaveLength(2);
+      expect(plan.actions[0]).toMatchObject({ packageName: "pkg-a", oldVersion: "1.0.0", newVersion: "1.0.1" });
+      expect(plan.actions[1]).toMatchObject({ packageName: "pkg-c", oldVersion: "1.0.0", newVersion: "1.0.1" });
+    });
   });
 });

--- a/packages/chronus/src/release-plan/assemble-release-plan.test.ts
+++ b/packages/chronus/src/release-plan/assemble-release-plan.test.ts
@@ -101,6 +101,7 @@ describe("Assemble Release Plan", () => {
         [makeChangeset("pkg-a", "patch"), makeChangeset("pkg-c", "patch")],
         workspace,
         lockStepConfig,
+        { ignorePolicies: true },
       );
       expect(plan.actions).toHaveLength(2);
       expect(plan.actions[0]).toMatchObject({ packageName: "pkg-a", oldVersion: "1.0.0", newVersion: "1.0.1" });

--- a/packages/chronus/src/release-plan/assemble-release-plan.ts
+++ b/packages/chronus/src/release-plan/assemble-release-plan.ts
@@ -7,17 +7,22 @@ import { incrementVersion } from "./increment-version.js";
 import type { InternalReleaseAction } from "./types.internal.js";
 import type { ReleaseAction, ReleasePlan } from "./types.js";
 
+export interface ApplyChangesetsOptions {
+  ignorePolicies?: boolean;
+}
+
 export function assembleReleasePlan(
   changesets: NewChangeset[],
   workspace: Workspace,
   config: ChronusConfig,
+  options?: ApplyChangesetsOptions,
 ): ReleasePlan {
   const packagesByName = new Map(workspace.packages.map((pkg) => [pkg.name, pkg]));
   const requested = flattenReleases(changesets, packagesByName, []);
 
   const dependentsGraph = getDependentsGraph(workspace.packages);
   const internalActions = new Map<string, InternalReleaseAction>();
-  if (config.versionPolicies) {
+  if (config.versionPolicies && !options?.ignorePolicies) {
     for (const policy of config.versionPolicies) {
       if (policy.type === "lockstep") {
         for (const pkgName of policy.packages) {


### PR DESCRIPTION
Add ability to ignore the versioning policies. Can be useful to bump patch version of lockStep independently.