### PR TITLE
Release changes

### DIFF
--- a/.changeset/add-npm-support-2024-0-31-15-35-36.md
+++ b/.changeset/add-npm-support-2024-0-31-15-35-36.md
@@ -1,5 +1,0 @@
----
-"@chronus/chronus": minor
----
-
-Add support for npm workspaces

--- a/.changeset/empty-zoos-look.md
+++ b/.changeset/empty-zoos-look.md
@@ -1,5 +1,0 @@
----
-"@chronus/chronus": minor
----
-
-Resolve workspace automatically and option to configure which workspace manager to use in the config file.

--- a/.changeset/test-auto-release-2024-0-31-17-52-13.md
+++ b/.changeset/test-auto-release-2024-0-31-17-52-13.md
@@ -1,3 +1,0 @@
----
-"@chronus/chronus": none
----

--- a/packages/chronus/CHANGELOG.md
+++ b/packages/chronus/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @chronus/chronus
 
+## 0.4.0
+
+### Minor Changes
+
+- 7d0680d: Add support for npm workspaces
+- cccd505: Resolve workspace automatically and option to configure which workspace manager to use in the config file.
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/chronus/package.json
+++ b/packages/chronus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/chronus",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "chronus",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/github-pr-commenter/CHANGELOG.md
+++ b/packages/github-pr-commenter/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @chronus/github-pr-commenter
 
+## 0.1.5
+
+### Patch Changes
+
+- Updated dependencies [7d0680d]
+- Updated dependencies [cccd505]
+- Updated dependencies [d0b8f43]
+  - @chronus/chronus@0.4.0
+
 ## 0.1.4
 
 ### Patch Changes

--- a/packages/github-pr-commenter/package.json
+++ b/packages/github-pr-commenter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/github-pr-commenter",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "chronus",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION

## Change summary:

### No packages to be bumped at **major**

### 1 packages to be bumped at **minor**:
- @chronus/chronus `0.3.0` → `0.4.0`

### 1 packages to be bumped at **patch**:
- @chronus/github-pr-commenter `0.1.4` → `0.1.5`
