### PR TITLE
Release changes

### DIFF
--- a/.changeset/feature-ignore-deps-2024-1-1-23-17-9.md
+++ b/.changeset/feature-ignore-deps-2024-1-1-23-17-9.md
@@ -1,5 +1,0 @@
----
-"@chronus/chronus": minor
----
-
-Add ability to ignore packages

--- a/.changeset/fix-glob-issue-2024-1-1-22-43-17.md
+++ b/.changeset/fix-glob-issue-2024-1-1-22-43-17.md
@@ -1,5 +1,0 @@
----
-"@chronus/chronus": patch
----
-
-Fix issue with globbing pointing to a dir causing into a globbing of everything underneath 

--- a/packages/chronus/CHANGELOG.md
+++ b/packages/chronus/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @chronus/chronus
 
+## 0.5.0
+
+### Minor Changes
+
+- b140705: Add ability to ignore packages
+
+### Patch Changes
+
+- 0a8ebe6: Fix issue with globbing pointing to a dir causing into a globbing of everything underneath
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/chronus/package.json
+++ b/packages/chronus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/chronus",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "chronus",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/github-pr-commenter/CHANGELOG.md
+++ b/packages/github-pr-commenter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @chronus/github-pr-commenter
 
+## 0.1.6
+
+### Patch Changes
+
+- Updated dependencies [b140705]
+- Updated dependencies [0a8ebe6]
+  - @chronus/chronus@0.5.0
+
 ## 0.1.5
 
 ### Patch Changes

--- a/packages/github-pr-commenter/package.json
+++ b/packages/github-pr-commenter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/github-pr-commenter",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "chronus",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION

## Change summary:

### No packages to be bumped at **major**

### 1 packages to be bumped at **minor**:
- @chronus/chronus `0.4.0` → `0.5.0`

### 1 packages to be bumped at **patch**:
- @chronus/github-pr-commenter `0.1.5` → `0.1.6`
