### PR TITLE
Release changes

### DIFF
--- a/.changeset/fix-ignoring-packages-using-deps-2024-1-3-3-53-21.md
+++ b/.changeset/fix-ignoring-packages-using-deps-2024-1-3-3-53-21.md
@@ -1,5 +1,0 @@
----
-"@chronus/chronus": patch
----
-
-Fix: ignoring packages having dependencies on package being bumped

--- a/packages/chronus/CHANGELOG.md
+++ b/packages/chronus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chronus/chronus
 
+## 0.5.1
+
+### Patch Changes
+
+- e32943e: Fix: ignoring packages having dependencies on package being bumped
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/chronus/package.json
+++ b/packages/chronus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/chronus",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "chronus",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/github-pr-commenter/CHANGELOG.md
+++ b/packages/github-pr-commenter/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @chronus/github-pr-commenter
 
+## 0.1.7
+
+### Patch Changes
+
+- Updated dependencies [e32943e]
+  - @chronus/chronus@0.5.1
+
 ## 0.1.6
 
 ### Patch Changes

--- a/packages/github-pr-commenter/package.json
+++ b/packages/github-pr-commenter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/github-pr-commenter",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "chronus",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION

## Change summary:

### No packages to be bumped at **major**

### No packages to be bumped at **minor**

### 2 packages to be bumped at **patch**:
- @chronus/chronus `0.5.0` → `0.5.1`
- @chronus/github-pr-commenter `0.1.6` → `0.1.7`
