### PR TITLE
Release changes

### DIFF
--- a/packages/chronus/CHANGELOG.md
+++ b/packages/chronus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chronus/chronus
 
+## 0.6.0
+
+### Minor Changes
+
+- Add ability to define a different set of change kinds. For example: Feature, Breaking, Deprecation, Fix, Internal, etc.
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/chronus/package.json
+++ b/packages/chronus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/chronus",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "chronus",
   "type": "module",
   "bin": {

--- a/packages/github-pr-commenter/CHANGELOG.md
+++ b/packages/github-pr-commenter/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @chronus/github-pr-commenter
 
+## 0.2.0
+
+### Minor Changes
+
+- Add ability to define a different set of change kinds. For example: Feature, Breaking, Deprecation, Fix, Internal, etc.
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+  - @chronus/chronus@0.6.0
+
 ## 0.1.7
 
 ### Patch Changes

--- a/packages/github-pr-commenter/package.json
+++ b/packages/github-pr-commenter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/github-pr-commenter",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "description": "chronus",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION

## Change summary:

### No packages to be bumped at **major**

### 2 packages to be bumped at **minor**:
- @chronus/chronus `0.5.1` → `0.6.0`
- @chronus/github-pr-commenter `0.1.7` → `0.2.0`

### No packages to be bumped at **patch**
