### PR TITLE
Release changes

### DIFF
--- a/.chronus/changes/fix-delete-change-after-release-2024-1-9-19-58-7.md
+++ b/.chronus/changes/fix-delete-change-after-release-2024-1-9-19-58-7.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@chronus/chronus"
----
-
-Delete change files after bumping versions

--- a/packages/chronus/CHANGELOG.md
+++ b/packages/chronus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chronus/chronus
 
+## 0.6.1
+
+### Patch Changes
+
+- Delete change files after bumping versions
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/chronus/package.json
+++ b/packages/chronus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/chronus",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "chronus",
   "type": "module",
   "bin": {

--- a/packages/github-pr-commenter/CHANGELOG.md
+++ b/packages/github-pr-commenter/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @chronus/github-pr-commenter
 
+## 0.2.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @chronus/chronus@0.6.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/github-pr-commenter/package.json
+++ b/packages/github-pr-commenter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/github-pr-commenter",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "chronus",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION

## Change summary:

### No packages to be bumped at **major**

### No packages to be bumped at **minor**

### 2 packages to be bumped at **patch**:
- @chronus/chronus `0.6.0` → `0.6.1`
- @chronus/github-pr-commenter `0.2.1` → `0.2.2`
