### PR TITLE
Release changes

### DIFF
--- a/.chronus/changes/changekind-default-2024-1-11-17-8-30.md
+++ b/.chronus/changes/changekind-default-2024-1-11-17-8-30.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: feature
-packages:
-  - "@chronus/github-pr-commenter"
----
-
-Change logic to resolve the default changekind on github commenter

--- a/.chronus/changes/feature-new-changelog-gen-2024-1-11-18-31-13.md
+++ b/.chronus/changes/feature-new-changelog-gen-2024-1-11-18-31-13.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: feature
-packages:
-  - "@chronus/chronus"
----
-
-Feature: New apply changes system that respect the change kinds names

--- a/.chronus/changes/read-all-2024-1-14-22-53-40.md
+++ b/.chronus/changes/read-all-2024-1-14-22-53-40.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: feature
-packages:
-  - "@chronus/chronus"
----
-
-Add new function to `@chornus/chronus/change` `readChangeDescriptions` that list all change descriptions in the workspace currently.

--- a/packages/chronus/CHANGELOG.md
+++ b/packages/chronus/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @chronus/chronus
 
+## 0.7.0
+
+### Features
+ 
+- Feature: New apply changes system that respect the change kinds names
+- Add new function to `@chornus/chronus/change` `readChangeDescriptions` that list all change descriptions in the workspace currently.
+
 ## 0.6.1
 
 ### Patch Changes

--- a/packages/chronus/package.json
+++ b/packages/chronus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/chronus",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "chronus",
   "type": "module",
   "bin": {

--- a/packages/github-pr-commenter/CHANGELOG.md
+++ b/packages/github-pr-commenter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chronus/github-pr-commenter
 
+## 0.3.0
+
+### Features
+ 
+- Change logic to resolve the default changekind on github commenter
+
 ## 0.2.3
 
 ### Patch Changes

--- a/packages/github-pr-commenter/package.json
+++ b/packages/github-pr-commenter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/github-pr-commenter",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "chronus",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION

## Change summary:

### No packages to be bumped at **major**

### 2 packages to be bumped at **minor**:
- @chronus/github-pr-commenter `0.2.3` → `0.3.0`
- @chronus/chronus `0.6.1` → `0.7.0`

### No packages to be bumped at **patch**
