### PR TITLE
Release changes

### DIFF
--- a/.chronus/changes/auto-select-pkgs-2024-1-24-9-22-27.md
+++ b/.chronus/changes/auto-select-pkgs-2024-1-24-9-22-27.md
@@ -1,7 +1,0 @@
----
-changeKind: feature
-packages:
-  - "@chronus/chronus"
----
-
-Auto-Select the undocumented packages when using `chronus add`

--- a/.chronus/changes/bulk-publish-tarballs-2024-2-1-23-25-31.md
+++ b/.chronus/changes/bulk-publish-tarballs-2024-2-1-23-25-31.md
@@ -1,9 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: fix
-packages:
-  - "@chronus/chronus"
-  - "@chronus/github-pr-commenter"
----
-
-Only include necessary files in artifact

--- a/.chronus/changes/bulk-publish-tarballs-2024-2-1-3-42-58.md
+++ b/.chronus/changes/bulk-publish-tarballs-2024-2-1-3-42-58.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: feature
-packages:
-  - "@chronus/chronus"
----
-
-`chronus publish` can take a wild card of tgz to publish instead of publishing the workspace

--- a/.chronus/changes/bulk-publish-tarballs-23024-2-1-3-42-58.md
+++ b/.chronus/changes/bulk-publish-tarballs-23024-2-1-3-42-58.md
@@ -1,6 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: internal
-packages:
-  - "@chronus/dummy"
----

--- a/.chronus/changes/feature-eslint-flat-config-2024-1-24-22-43-32.md
+++ b/.chronus/changes/feature-eslint-flat-config-2024-1-24-22-43-32.md
@@ -1,9 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: internal
-packages:
-  - "@chronus/chronus"
-  - "@chronus/github-pr-commenter"
----
-
-Migrate to eslint flat config

--- a/.chronus/changes/feature-pack-2024-1-27-2-7-8.md
+++ b/.chronus/changes/feature-pack-2024-1-27-2-7-8.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: feature
-packages:
-  - "@chronus/chronus"
----
-
-Add `chronus pack` command that will pack all packages that need publishing

--- a/.chronus/changes/feature-partial-release-2024-1-24-21-34-56.md
+++ b/.chronus/changes/feature-partial-release-2024-1-24-21-34-56.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: fix
-packages:
-  - "@chronus/chronus"
----
-
-Partial Release using `--only` to bump version of select packages

--- a/.chronus/changes/feature-publish-2024-1-28-16-36-37.md
+++ b/.chronus/changes/feature-publish-2024-1-28-16-36-37.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: feature
-packages:
-  - "@chronus/chronus"
----
-
-Add new `chronus publish` command to publish all packages in the workspace

--- a/.chronus/changes/feature-publish-2024-1-28-16-45-15.md
+++ b/.chronus/changes/feature-publish-2024-1-28-16-45-15.md
@@ -1,6 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: internal
-packages:
-  - "@chronus/dummy"
----

--- a/.chronus/changes/fix-allow-to-choose-publish-engine-2024-2-3-22-39-3.md
+++ b/.chronus/changes/fix-allow-to-choose-publish-engine-2024-2-3-22-39-3.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: fix
-packages:
-  - "@chronus/chronus"
----
-
-Allow to choose publish engine

--- a/.chronus/changes/fix-get-commits-2024-2-3-23-6-47.md
+++ b/.chronus/changes/fix-get-commits-2024-2-3-23-6-47.md
@@ -1,6 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: internal
-packages:
-  - "@chronus/chronus"
----

--- a/.chronus/changes/fix-spellcheck-2024-1-25-2-35-29.md
+++ b/.chronus/changes/fix-spellcheck-2024-1-25-2-35-29.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: internal
-packages:
-  - "@chronus/chronus"
----
-
-Fix spellcheck run on everything

--- a/.chronus/changes/gh-interactive-login-2024-2-3-22-19-53.md
+++ b/.chronus/changes/gh-interactive-login-2024-2-3-22-19-53.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: fix
-packages:
-  - "@chronus/github"
----
-
-Add github interactive login

--- a/.chronus/changes/gh-interactive-login-2024-2-3-22-21-25.md
+++ b/.chronus/changes/gh-interactive-login-2024-2-3-22-21-25.md
@@ -1,6 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: internal
-packages:
-  - "@chronus/chronus"
----

--- a/.chronus/changes/github-changelog-2024-2-3-13-44-18.md
+++ b/.chronus/changes/github-changelog-2024-2-3-13-44-18.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@chronus/chronus"
----
-
-Fix issue where a change kind with version kind of `none` would still be included in the changelog

--- a/.chronus/changes/github-changelog-2024-2-3-21-41-112.md
+++ b/.chronus/changes/github-changelog-2024-2-3-21-41-112.md
@@ -1,6 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: internal
-packages:
-  - "@chronus/github"
----

--- a/.chronus/changes/github-changelog-2024-2-3-21-41-19.md
+++ b/.chronus/changes/github-changelog-2024-2-3-21-41-19.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: feature
-packages:
-  - "@chronus/chronus"
----
-
-Add ability to configure the changelog generator with a `changelog` entry

--- a/.chronus/changes/list-unpublished-packages-2024-1-25-3-36-30.md
+++ b/.chronus/changes/list-unpublished-packages-2024-1-25-3-36-30.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: fix
-packages:
-  - "@chronus/chronus"
----
-
-Add new `list-pending-publish` command to list unpublished packages

--- a/.chronus/changes/more-eslint-tweaks-2024-1-25-0-47-30.md
+++ b/.chronus/changes/more-eslint-tweaks-2024-1-25-0-47-30.md
@@ -1,9 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: internal
-packages:
-  - "@chronus/chronus"
-  - "@chronus/github-pr-commenter"
----
-
-More tweaks of eslint

--- a/packages/chronus/CHANGELOG.md
+++ b/packages/chronus/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @chronus/chronus
 
+## 0.8.0
+
+### Features
+
+- [#78](https://github.com/timotheeguerin/chronus/pull/78) Auto-Select the undocumented packages when using `chronus add`
+- [#96](https://github.com/timotheeguerin/chronus/pull/96) `chronus publish` can take a wild card of tgz to publish instead of publishing the workspace
+- [#92](https://github.com/timotheeguerin/chronus/pull/92) Add `chronus pack` command that will pack all packages that need publishing
+- [#94](https://github.com/timotheeguerin/chronus/pull/94) Add new `chronus publish` command to publish all packages in the workspace
+- [#97](https://github.com/timotheeguerin/chronus/pull/97) Add ability to configure the changelog generator with a `changelog` entry
+
+### Bug Fixes
+
+- [#96](https://github.com/timotheeguerin/chronus/pull/96) Only include necessary files in artifact
+- [#80](https://github.com/timotheeguerin/chronus/pull/80) Partial Release using `--only` to bump version of select packages
+- [#99](https://github.com/timotheeguerin/chronus/pull/99) Allow to choose publish engine
+- [#97](https://github.com/timotheeguerin/chronus/pull/97) Fix issue where a change kind with version kind of `none` would still be included in the changelog
+- [#84](https://github.com/timotheeguerin/chronus/pull/84) Add new `list-pending-publish` command to list unpublished packages
+
+
 ## 0.7.0
 
 ### Features

--- a/packages/chronus/package.json
+++ b/packages/chronus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/chronus",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "chronus",
   "type": "module",
   "bin": {

--- a/packages/github-pr-commenter/CHANGELOG.md
+++ b/packages/github-pr-commenter/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @chronus/github-pr-commenter
 
+## 0.3.1
+
+### Bug Fixes
+
+- [#96](https://github.com/timotheeguerin/chronus/pull/96) Only include necessary files in artifact
+
+
 ## 0.3.0
 
 ### Features

--- a/packages/github-pr-commenter/package.json
+++ b/packages/github-pr-commenter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/github-pr-commenter",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "chronus",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/github",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "chronus",
   "main": "dist/index.js",
   "exports": {


### PR DESCRIPTION

## Change summary:

### No packages to be bumped at **major**

### 1 packages to be bumped at **minor**:
- @chronus/chronus `0.7.0` → `0.8.0`

### 2 packages to be bumped at **patch**:
- @chronus/github-pr-commenter `0.3.0` → `0.3.1`
- @chronus/github `0.1.0` → `0.1.1`
