### PR TITLE
Release changes

### DIFF
--- a/.chronus/changes/github-release-2024-2-4-4-44-26.md
+++ b/.chronus/changes/github-release-2024-2-4-4-44-26.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: fix
-packages:
-  - "@chronus/github"
----
-
-Add a new cli and command `create-release` to publish github release from a publish report created by the `chronus publish` command 

--- a/.chronus/changes/github-release-2024-2-4-4-45-52.md
+++ b/.chronus/changes/github-release-2024-2-4-4-45-52.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: fix
-packages:
-  - "@chronus/chronus"
----
-
-Export `readPublishSummary` function from `@chronus/chronus/publish`

--- a/.chronus/changes/publish-summary-2024-2-4-3-44-27.md
+++ b/.chronus/changes/publish-summary-2024-2-4-3-44-27.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: fix
-packages:
-  - "@chronus/chronus"
----
-
-Add `--report-summary` to `publish` command to save a report summary 

--- a/packages/chronus/CHANGELOG.md
+++ b/packages/chronus/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @chronus/chronus
 
+## 0.8.1
+
+### Bug Fixes
+
+- [#106](https://github.com/timotheeguerin/chronus/pull/106) Export `readPublishSummary` function from `@chronus/chronus/publish`
+- [#104](https://github.com/timotheeguerin/chronus/pull/104) Add `--report-summary` to `publish` command to save a report summary
+
+
 ## 0.8.0
 
 ### Features

--- a/packages/chronus/package.json
+++ b/packages/chronus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/chronus",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "chronus",
   "type": "module",
   "bin": {

--- a/packages/github-pr-commenter/CHANGELOG.md
+++ b/packages/github-pr-commenter/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @chronus/github-pr-commenter
 
+## 0.3.2
+
+No changes, version bump only.
+
 ## 0.3.1
 
 ### Bug Fixes

--- a/packages/github-pr-commenter/package.json
+++ b/packages/github-pr-commenter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/github-pr-commenter",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "chronus",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/github",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "chronus",
   "main": "dist/index.js",
   "exports": {


### PR DESCRIPTION

## Change summary:

### No packages to be bumped at **major**

### No packages to be bumped at **minor**

### 3 packages to be bumped at **patch**:
- @chronus/github `0.1.1` → `0.1.2`
- @chronus/chronus `0.8.0` → `0.8.1`
- @chronus/github-pr-commenter `0.3.1` → `0.3.2`
