### PR TITLE
Release changes

### DIFF
--- a/.chronus/changes/publish-individual-2024-2-4-16-30-3.md
+++ b/.chronus/changes/publish-individual-2024-2-4-16-30-3.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: feature
-packages:
-  - "@chronus/github"
----
-
-Add options to `create-releases` command to create release for individual package versions

--- a/.chronus/changes/publish-individual-2024-2-4-16-304-3.md
+++ b/.chronus/changes/publish-individual-2024-2-4-16-304-3.md
@@ -1,6 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: internal
-packages:
-  - "@chronus/chronus"
----

--- a/.chronus/changes/publish-policies-2024-2-5-18-41-52.md
+++ b/.chronus/changes/publish-policies-2024-2-5-18-41-52.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: fix
-packages:
-  - "@chronus/github"
----
-
-Lock step policies will be automatically grouped into a single github release

--- a/.chronus/changes/publish-policies-2024-2-5-19-12-24.md
+++ b/.chronus/changes/publish-policies-2024-2-5-19-12-24.md
@@ -1,7 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: fix
-packages:
-  - "@chronus/chronus"
----
-[API] More accurate type for lockstep version policy step

--- a/packages/chronus/CHANGELOG.md
+++ b/packages/chronus/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @chronus/chronus
 
+## 0.8.2
+
+### Bug Fixes
+
+- [#115](https://github.com/timotheeguerin/chronus/pull/115) [API] More accurate type for lockstep version policy step
+
+
 ## 0.8.1
 
 ### Bug Fixes

--- a/packages/chronus/package.json
+++ b/packages/chronus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/chronus",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "chronus",
   "type": "module",
   "bin": {

--- a/packages/github-pr-commenter/CHANGELOG.md
+++ b/packages/github-pr-commenter/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @chronus/github-pr-commenter
 
+## 0.3.3
+
+No changes, version bump only.
+
 ## 0.3.2
 
 No changes, version bump only.

--- a/packages/github-pr-commenter/package.json
+++ b/packages/github-pr-commenter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/github-pr-commenter",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "chronus",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/github",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "chronus",
   "main": "dist/index.js",
   "exports": {


### PR DESCRIPTION

## Change summary:

### No packages to be bumped at **major**

### 1 packages to be bumped at **minor**:
- @chronus/github `0.1.2` → `0.2.0`

### 2 packages to be bumped at **patch**:
- @chronus/chronus `0.8.1` → `0.8.2`
- @chronus/github-pr-commenter `0.3.2` → `0.3.3`
