### PR TITLE
Release changes

### DIFF
--- a/.chronus/changes/publish-with-tag-2024-2-7-1-51-16.md
+++ b/.chronus/changes/publish-with-tag-2024-2-7-1-51-16.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: fix
-packages:
-  - "@chronus/chronus"
----
-
-Add support for `--tag` when publishing

--- a/packages/chronus/CHANGELOG.md
+++ b/packages/chronus/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @chronus/chronus
 
+## 0.8.3
+
+### Bug Fixes
+
+- [#119](https://github.com/timotheeguerin/chronus/pull/119) Add support for `--tag` when publishing
+
+
 ## 0.8.2
 
 ### Bug Fixes

--- a/packages/chronus/package.json
+++ b/packages/chronus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/chronus",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "chronus",
   "type": "module",
   "bin": {

--- a/packages/github-pr-commenter/CHANGELOG.md
+++ b/packages/github-pr-commenter/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @chronus/github-pr-commenter
 
+## 0.3.4
+
+No changes, version bump only.
+
 ## 0.3.3
 
 No changes, version bump only.

--- a/packages/github-pr-commenter/package.json
+++ b/packages/github-pr-commenter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/github-pr-commenter",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "chronus",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/github",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "chronus",
   "main": "dist/index.js",
   "exports": {


### PR DESCRIPTION

## Change summary:

### No packages to be bumped at **major**

### No packages to be bumped at **minor**

### 3 packages to be bumped at **patch**:
- @chronus/chronus `0.8.2` → `0.8.3`
- @chronus/github `0.2.1` → `0.2.2`
- @chronus/github-pr-commenter `0.3.3` → `0.3.4`
