### PR TITLE
Release changes

### DIFF
--- a/.chronus/changes/add-verify-since-2024-3-9-14-29-5.md
+++ b/.chronus/changes/add-verify-since-2024-3-9-14-29-5.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: feature
-packages:
-  - "@chronus/chronus"
----
-
-Add `--since` option to add and verify command to be able to use against a different branch

--- a/.chronus/changes/feature-aggregated-changelog-gen-2024-3-3-4-6-15.md
+++ b/.chronus/changes/feature-aggregated-changelog-gen-2024-3-3-4-6-15.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: feature
-packages:
-  - "@chronus/chronus"
----
-
-Add new `changelog` command to generate the changelog entry for a package or policy without bumping versions

--- a/.chronus/changes/feature-aggregated-changelog-gen-2024-3-3-4-6-30.md
+++ b/.chronus/changes/feature-aggregated-changelog-gen-2024-3-3-4-6-30.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: feature
-packages:
-  - "@chronus/github"
----
-
-Add support for aggregated changelog

--- a/.chronus/changes/feature-detect-changes-2024-3-7-20-43-24.md
+++ b/.chronus/changes/feature-detect-changes-2024-3-7-20-43-24.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: feature
-packages:
-  - "@chronus/chronus"
----
-
-Feature: Add new configuration `changedFiles` to filter which files can trigger change

--- a/.chronus/changes/fork-registry-2024-2-9-4-21-30.md
+++ b/.chronus/changes/fork-registry-2024-2-9-4-21-30.md
@@ -1,7 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: internal
-packages:
-  - "@chronus/chronus"
-  - "@chronus/github"
----

--- a/.chronus/changes/update-deps-2024-3-7-20-57-57.md
+++ b/.chronus/changes/update-deps-2024-3-7-20-57-57.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: internal
-packages:
-  - "@chronus/chronus"
-  - "@chronus/github-pr-commenter"
-  - "@chronus/github"
----

--- a/packages/chronus/CHANGELOG.md
+++ b/packages/chronus/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @chronus/chronus
 
+## 0.9.0
+
+### Features
+
+- [#150](https://github.com/timotheeguerin/chronus/pull/150) Add `--since` option to add and verify command to be able to use against a different branch
+- [#144](https://github.com/timotheeguerin/chronus/pull/144) Add new `changelog` command to generate the changelog entry for a package or policy without bumping versions
+- [#147](https://github.com/timotheeguerin/chronus/pull/147) Feature: Add new configuration `changedFiles` to filter which files can trigger change
+
+
 ## 0.8.3
 
 ### Bug Fixes

--- a/packages/chronus/package.json
+++ b/packages/chronus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/chronus",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "chronus",
   "type": "module",
   "bin": {

--- a/packages/github-pr-commenter/CHANGELOG.md
+++ b/packages/github-pr-commenter/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @chronus/github-pr-commenter
 
+## 0.3.5
+
+No changes, version bump only.
+
 ## 0.3.4
 
 No changes, version bump only.

--- a/packages/github-pr-commenter/package.json
+++ b/packages/github-pr-commenter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/github-pr-commenter",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "chronus",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/github",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "chronus",
   "main": "dist/index.js",
   "exports": {


### PR DESCRIPTION

## Change summary:

### No packages to be bumped at **major**

### 2 packages to be bumped at **minor**:
- @chronus/chronus `0.8.3` → `0.9.0`
- @chronus/github `0.2.2` → `0.3.0`

### 1 packages to be bumped at **patch**:
- @chronus/github-pr-commenter `0.3.4` → `0.3.5`
