### PR TITLE
Release changes

### DIFF
--- a/.chronus/changes/fix-publish-tag-2024-3-15-20-56-1.md
+++ b/.chronus/changes/fix-publish-tag-2024-3-15-20-56-1.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: fix
-packages:
-  - "@chronus/chronus"
----
-
-Fix `--tag` not respected

--- a/packages/chronus/CHANGELOG.md
+++ b/packages/chronus/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @chronus/chronus
 
+## 0.10.1
+
+### Bug Fixes
+
+- [#165](https://github.com/timotheeguerin/chronus/pull/165) Fix `--tag` not respected
+
+
 ## 0.10.0
 
 ### Features

--- a/packages/chronus/package.json
+++ b/packages/chronus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/chronus",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "type": "module",
   "description": "chronus",
   "homepage": "https://github.com/timotheeguerin/chronus#readme",

--- a/packages/github-pr-commenter/CHANGELOG.md
+++ b/packages/github-pr-commenter/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @chronus/github-pr-commenter
 
+## 0.4.1
+
+No changes, version bump only.
+
 ## 0.4.0
 
 ### Features

--- a/packages/github-pr-commenter/package.json
+++ b/packages/github-pr-commenter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/github-pr-commenter",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "description": "chronus",
   "homepage": "https://github.com/timotheeguerin/chronus#readme",

--- a/packages/github/CHANGELOG.md
+++ b/packages/github/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog - @chronus/github
 
+## 0.3.3
+
+No changes, version bump only.
+
 ## 0.3.2
 
 No changes, version bump only.

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/github",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "description": "chronus",
   "homepage": "https://github.com/timotheeguerin/chronus#readme",


### PR DESCRIPTION

## Change summary:

### No packages to be bumped at **major**

### No packages to be bumped at **minor**

### 3 packages to be bumped at **patch**:
- @chronus/chronus `0.10.0` → `0.10.1`
- @chronus/github `0.3.2` → `0.3.3`
- @chronus/github-pr-commenter `0.4.0` → `0.4.1`
