### PR TITLE
Release changes

### DIFF
--- a/.chronus/changes/prerelease-bumping-2024-7-4-20-32-18.md
+++ b/.chronus/changes/prerelease-bumping-2024-7-4-20-32-18.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: feature
-packages:
-  - "@chronus/chronus"
----
-
-Add new `--prerelease` flag to `chronus version` command allowing bumping of versions for a reprelease build

--- a/.chronus/changes/upgrade-deps-aug-4-2024-7-4-20-48-47.md
+++ b/.chronus/changes/upgrade-deps-aug-4-2024-7-4-20-48-47.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: internal
-packages:
-  - "@chronus/chronus"
----
-
-Update dependencies

--- a/.chronus/changes/upgrade-deps-aug-4-2024-7-4-21-7-18.md
+++ b/.chronus/changes/upgrade-deps-aug-4-2024-7-4-21-7-18.md
@@ -1,9 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: internal
-packages:
-  - "@chronus/github-pr-commenter"
-  - "@chronus/github"
----
-
-Update dependencies

--- a/packages/chronus/CHANGELOG.md
+++ b/packages/chronus/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @chronus/chronus
 
+## 0.12.0
+
+### Features
+
+- [#255](https://github.com/timotheeguerin/chronus/pull/255) Add new `--prerelease` flag to `chronus version` command allowing bumping of versions for a reprelease build
+
+
 ## 0.11.0
 
 ### Features

--- a/packages/chronus/package.json
+++ b/packages/chronus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/chronus",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "type": "module",
   "description": "chronus",
   "homepage": "https://github.com/timotheeguerin/chronus#readme",

--- a/packages/github-pr-commenter/CHANGELOG.md
+++ b/packages/github-pr-commenter/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @chronus/github-pr-commenter
 
+## 0.5.2
+
+No changes, version bump only.
+
 ## 0.5.1
 
 No changes, version bump only.

--- a/packages/github-pr-commenter/package.json
+++ b/packages/github-pr-commenter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/github-pr-commenter",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "description": "chronus",
   "homepage": "https://github.com/timotheeguerin/chronus#readme",

--- a/packages/github/CHANGELOG.md
+++ b/packages/github/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog - @chronus/github
 
+## 0.4.2
+
+No changes, version bump only.
+
 ## 0.4.1
 
 No changes, version bump only.

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/github",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "description": "chronus",
   "homepage": "https://github.com/timotheeguerin/chronus#readme",


### PR DESCRIPTION

## Change summary:

### No packages to be bumped at **major**

### 1 packages to be bumped at **minor**:
- @chronus/chronus `0.11.0` → `0.12.0`

### 2 packages to be bumped at **patch**:
- @chronus/github-pr-commenter `0.5.1` → `0.5.2`
- @chronus/github `0.4.1` → `0.4.2`
