### PR TITLE
Fix regex performance issues

### DIFF
--- a/.chronus/changes/fix-code-scan-alter-2024-7-5-15-43-49.md
+++ b/.chronus/changes/fix-code-scan-alter-2024-7-5-15-43-49.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: breaking, feature, fix, internal
+changeKind: fix
+packages:
+  - "@chronus/chronus"
+---
+
+Fix regex performance issues

--- a/packages/chronus/src/change/parse.ts
+++ b/packages/chronus/src/change/parse.ts
@@ -8,7 +8,7 @@ import { parseYaml } from "../yaml/parse.js";
 import { validateYamlFile } from "../yaml/schema-validator.js";
 import type { ChangeDescription, ChangeDescriptionFrontMatter } from "./types.js";
 
-const mdRegex = /\s*---([^]*?)\n\s*---(\s*(?:\n|$)[^]*)/;
+const mdRegex = /^\s*---([^]*?)\n---\n([^]*)/;
 
 const changeFrontMatterSchema = z.object({
   changeKind: z.string(),

--- a/packages/chronus/src/utils/misc-utils.test.ts
+++ b/packages/chronus/src/utils/misc-utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { getLastJsonObject } from "./misc-utils.js";
+
+describe("getLastJsonObject", () => {
+  it("parse when whole string is a json object", () => {
+    const json = '{"a": 1, "b": 2}';
+    expect(getLastJsonObject(json)).toEqual({ a: 1, b: 2 });
+  });
+
+  it("parse when there is some leading whitespace", () => {
+    const json = '       {"a": 1, "b": 2}';
+    expect(getLastJsonObject(json)).toEqual({ a: 1, b: 2 });
+  });
+
+  it("parse when there is some trailing whitespace", () => {
+    const json = '{"a": 1, "b": 2}           ';
+    expect(getLastJsonObject(json)).toEqual({ a: 1, b: 2 });
+  });
+
+  it("parse when there is some newlines", () => {
+    const json = 'Result:\n{"a": 1, "b": 2}\nDone.';
+    expect(getLastJsonObject(json)).toEqual({ a: 1, b: 2 });
+  });
+
+  it("parse when json string contains { and }", () => {
+    const json = 'Result:\n{"a": "some { and } contained here", "b": 2}\nDone.';
+    expect(getLastJsonObject(json)).toEqual({ a: "some { and } contained here", b: 2 });
+  });
+});

--- a/packages/chronus/src/utils/misc-utils.ts
+++ b/packages/chronus/src/utils/misc-utils.ts
@@ -45,7 +45,6 @@ export function getLastJsonObject(str: string) {
     if (str[i] === "{") {
       start = i;
       try {
-        console.log("Try", str.slice(start, end + 1));
         return JSON.parse(str.slice(start, end + 1));
       } catch (err) {
         // ignore keep trying to look for previous { to parse

--- a/packages/chronus/src/utils/misc-utils.ts
+++ b/packages/chronus/src/utils/misc-utils.ts
@@ -32,16 +32,24 @@ export function prettyBytes(bytes: number, decimals = 2) {
 }
 
 export function getLastJsonObject(str: string) {
-  str = str.replace(/[^}]*$/, "");
+  let start = 0;
+  let end = str.length - 1;
+  for (let i = str.length - 1; i >= 0; i--) {
+    if (str[i] === "}") {
+      end = i;
+      break;
+    }
+  }
 
-  while (str) {
-    str = str.replace(/[^{]*/, "");
-
-    try {
-      return JSON.parse(str);
-    } catch (err) {
-      // move past the potentially leading `{` so the regexp in the loop can try to match for the next `{`
-      str = str.slice(1);
+  for (let i = end; i >= 0; i--) {
+    if (str[i] === "{") {
+      start = i;
+      try {
+        console.log("Try", str.slice(start, end + 1));
+        return JSON.parse(str.slice(start, end + 1));
+      } catch (err) {
+        // ignore keep trying to look for previous { to parse
+      }
     }
   }
   return null;


### PR DESCRIPTION
From code scanning alert.

Replace the json line parser with loop
Simplify the front matter parsing as `---` can only be used as the first chars 