### PR TITLE
Release changes

### DIFF
--- a/.chronus/changes/fix-code-scan-alter-2024-7-5-15-43-49.md
+++ b/.chronus/changes/fix-code-scan-alter-2024-7-5-15-43-49.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: fix
-packages:
-  - "@chronus/chronus"
----
-
-Fix regex performance issues

--- a/.chronus/changes/fix-workspace-protocol-deps-2024-8-12-21-13-6.md
+++ b/.chronus/changes/fix-workspace-protocol-deps-2024-8-12-21-13-6.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: fix
-packages:
-  - "@chronus/chronus"
----
-
-Fix incorrectly detecting packages as needing new version when using `workspace:` range

--- a/packages/chronus/CHANGELOG.md
+++ b/packages/chronus/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @chronus/chronus
 
+## 0.12.1
+
+### Bug Fixes
+
+- [#260](https://github.com/timotheeguerin/chronus/pull/260) Fix regex performance issues
+- [#282](https://github.com/timotheeguerin/chronus/pull/282) Fix incorrectly detecting packages as needing new version when using `workspace:` range
+
+
 ## 0.12.0
 
 ### Features

--- a/packages/chronus/package.json
+++ b/packages/chronus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/chronus",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "type": "module",
   "description": "chronus",
   "homepage": "https://github.com/timotheeguerin/chronus#readme",

--- a/packages/github-pr-commenter/CHANGELOG.md
+++ b/packages/github-pr-commenter/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @chronus/github-pr-commenter
 
+## 0.5.3
+
+No changes, version bump only.
+
 ## 0.5.2
 
 No changes, version bump only.

--- a/packages/github-pr-commenter/package.json
+++ b/packages/github-pr-commenter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/github-pr-commenter",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "type": "module",
   "description": "chronus",
   "homepage": "https://github.com/timotheeguerin/chronus#readme",

--- a/packages/github/CHANGELOG.md
+++ b/packages/github/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog - @chronus/github
 
+## 0.4.3
+
+No changes, version bump only.
+
 ## 0.4.2
 
 No changes, version bump only.

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/github",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "description": "chronus",
   "homepage": "https://github.com/timotheeguerin/chronus#readme",


### PR DESCRIPTION

## Change summary:

### No packages to be bumped at **major**

### No packages to be bumped at **minor**

### 3 packages to be bumped at **patch**:
- @chronus/chronus `0.12.0` → `0.12.1`
- @chronus/github `0.4.2` → `0.4.3`
- @chronus/github-pr-commenter `0.5.2` → `0.5.3`
