### PR TITLE
Release changes

### DIFF
--- a/.chronus/changes/expose-markdown-summary-2024-8-20-17-11-16.md
+++ b/.chronus/changes/expose-markdown-summary-2024-8-20-17-11-16.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: breaking, feature, fix, internal
-changeKind: feature
-packages:
-  - "@chronus/chronus"
----
-
-[API] Expose function to get markdown summary of release plan

--- a/.chronus/changes/fix-no-commits-2024-8-20-10-18-34.md
+++ b/.chronus/changes/fix-no-commits-2024-8-20-10-18-34.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@chronus/github"
----
-
-Fix trying to generate changelogs when no change would cause crash

--- a/packages/chronus/CHANGELOG.md
+++ b/packages/chronus/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @chronus/chronus
 
+## 0.13.0
+
+### Features
+
+- [#287](https://github.com/timotheeguerin/chronus/pull/287) [API] Expose function to get markdown summary of release plan
+
+
 ## 0.12.1
 
 ### Bug Fixes

--- a/packages/chronus/package.json
+++ b/packages/chronus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/chronus",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "type": "module",
   "description": "chronus",
   "homepage": "https://github.com/timotheeguerin/chronus#readme",

--- a/packages/github-pr-commenter/CHANGELOG.md
+++ b/packages/github-pr-commenter/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @chronus/github-pr-commenter
 
+## 0.5.4
+
+No changes, version bump only.
+
 ## 0.5.3
 
 No changes, version bump only.

--- a/packages/github-pr-commenter/package.json
+++ b/packages/github-pr-commenter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/github-pr-commenter",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "type": "module",
   "description": "chronus",
   "homepage": "https://github.com/timotheeguerin/chronus#readme",

--- a/packages/github/CHANGELOG.md
+++ b/packages/github/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog - @chronus/github
 
+## 0.4.4
+
+### Bug Fixes
+
+- [#288](https://github.com/timotheeguerin/chronus/pull/288) Fix trying to generate changelogs when no change would cause crash
+
+
 ## 0.4.3
 
 No changes, version bump only.

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronus/github",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "description": "chronus",
   "homepage": "https://github.com/timotheeguerin/chronus#readme",


### PR DESCRIPTION

## Change summary:

### No packages to be bumped at **major**

### 1 packages to be bumped at **minor**:
- @chronus/chronus `0.12.1` → `0.13.0`

### 2 packages to be bumped at **patch**:
- @chronus/github `0.4.3` → `0.4.4`
- @chronus/github-pr-commenter `0.5.3` → `0.5.4`
