### PR TITLE
Add `baseRemote` config option 

### DIFF
--- a/.chronus/changes/specify-remote-url-2025-2-21-16-29-0.md
+++ b/.chronus/changes/specify-remote-url-2025-2-21-16-29-0.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: breaking, feature, fix, internal
+changeKind: fix
+packages:
+  - "@chronus/chronus"
+---
+
+Add `baseRemote` config option allowing to explicitly define what is the base remote to compare against

--- a/.chronus/config.yaml
+++ b/.chronus/config.yaml
@@ -1,5 +1,5 @@
 baseBranch: main
-remote: https://github.com/timotheeguerin/chronus
+baseRemote: https://github.com/timotheeguerin/chronus
 changelog: ["@chronus/github/changelog", { repo: "timotheeguerin/chronus" }]
 changeKinds:
   breaking:

--- a/.chronus/config.yaml
+++ b/.chronus/config.yaml
@@ -1,4 +1,5 @@
 baseBranch: main
+remote: https://github.com/timotheeguerin/chronus
 changelog: ["@chronus/github/changelog", { repo: "timotheeguerin/chronus" }]
 changeKinds:
   breaking:

--- a/packages/chronus/src/change/find.ts
+++ b/packages/chronus/src/change/find.ts
@@ -40,7 +40,10 @@ export async function findChangeStatus(
   workspace: ChronusWorkspace,
   options?: FindChangeStatusOptions,
 ): Promise<ChangeStatus> {
-  const filesChanged = await sourceControl.listChangedFilesFromBase(options?.since ?? workspace.config.baseBranch);
+  const filesChanged = await sourceControl.listChangedFilesFromBase(
+    options?.since ?? workspace.config.baseBranch,
+    workspace.config.baseRemote,
+  );
   const untrackedOrModifiedFiles = await sourceControl.listUntrackedOrModifiedFiles();
   const stagedFiles = await sourceControl.listUntrackedOrModifiedFiles();
   const publicPackages = workspace.packages;

--- a/packages/chronus/src/cli/commands/add-changeset.ts
+++ b/packages/chronus/src/cli/commands/add-changeset.ts
@@ -26,7 +26,7 @@ async function resolvePackagesToInclude(
   status: ChangeStatus,
   packages?: string[],
 ): Promise<Package[] | undefined> {
-  if (packages === undefined) {
+  if (packages === undefined || packages.length === 0) {
     return await promptForPackages(status);
   }
   return packages.map((x) => {

--- a/packages/chronus/src/config/parse.ts
+++ b/packages/chronus/src/config/parse.ts
@@ -25,6 +25,7 @@ const changeKindsSchema = z.object({
 
 const schema = z.object({
   baseBranch: z.string(),
+  baseRemote: z.string().optional(),
   workspaceType: z.enum(["auto", "npm", "pnpm", "rush"]).optional(),
   additionalPackages: z.array(z.string()).optional(),
   versionPolicies: z.array(versionPolicySchema).optional(),

--- a/packages/chronus/src/config/parse.ts
+++ b/packages/chronus/src/config/parse.ts
@@ -4,17 +4,21 @@ import { parseYaml, validateYamlFile } from "../yaml/index.js";
 import type { ChronusUserConfig } from "./types.js";
 
 const versionPolicySchema = z.union([
-  z.object({
-    type: z.literal("lockstep"),
-    name: z.string(),
-    packages: z.array(z.string()),
-    step: z.enum(["major", "minor", "patch"]),
-  }),
-  z.object({
-    type: z.literal("independent"),
-    name: z.string(),
-    packages: z.array(z.string()),
-  }),
+  z
+    .object({
+      type: z.literal("lockstep"),
+      name: z.string(),
+      packages: z.array(z.string()),
+      step: z.enum(["major", "minor", "patch"]),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("independent"),
+      name: z.string(),
+      packages: z.array(z.string()),
+    })
+    .strict(),
 ]);
 
 const changeKindsSchema = z.object({
@@ -23,17 +27,19 @@ const changeKindsSchema = z.object({
   description: z.string().optional(),
 });
 
-const schema = z.object({
-  baseBranch: z.string(),
-  baseRemote: z.string().optional(),
-  workspaceType: z.enum(["auto", "npm", "pnpm", "rush"]).optional(),
-  additionalPackages: z.array(z.string()).optional(),
-  versionPolicies: z.array(versionPolicySchema).optional(),
-  ignore: z.array(z.string()).optional(),
-  changeKinds: z.record(changeKindsSchema).optional(),
-  changelog: z.union([z.string(), z.tuple([z.string(), z.record(z.unknown())])]).optional(),
-  changedFiles: z.array(z.string()).optional(),
-});
+const schema = z
+  .object({
+    baseBranch: z.string(),
+    baseRemote: z.string().url().optional(),
+    workspaceType: z.enum(["auto", "npm", "pnpm", "rush"]).optional(),
+    additionalPackages: z.array(z.string()).optional(),
+    versionPolicies: z.array(versionPolicySchema).optional(),
+    ignore: z.array(z.string()).optional(),
+    changeKinds: z.record(changeKindsSchema).optional(),
+    changelog: z.union([z.string(), z.tuple([z.string(), z.record(z.unknown())])]).optional(),
+    changedFiles: z.array(z.string()).optional(),
+  })
+  .strict();
 
 export function parseConfig(content: string | TextFile): ChronusUserConfig {
   const parsed = parseYaml(content);

--- a/packages/chronus/src/config/types.ts
+++ b/packages/chronus/src/config/types.ts
@@ -4,7 +4,11 @@ import type { YamlFile } from "../yaml/types.js";
 
 export interface ChronusUserConfig {
   readonly source?: YamlFile;
+  /** Base branch that should be used to compare */
   readonly baseBranch: string;
+  /** Base remote to use to compare against. Set this to the upstream remote to support forks that don't point their main branch to the upstream remote */
+  readonly baseRemote?: string;
+  /** Workspace type: pnpm, npm, yarn or auto */
   readonly workspaceType?: WorkspaceType | "auto";
   /** Additional packages that do not belong the workspace */
   readonly additionalPackages?: string[];

--- a/packages/chronus/src/source-control/git.ts
+++ b/packages/chronus/src/source-control/git.ts
@@ -74,7 +74,7 @@ export interface GitRepository {
    * Returns files changed from the base remote branch.
    * @param dir Repository directory
    */
-  listChangedFilesFromBase(baseBranch: string): Promise<string[]>;
+  listChangedFilesFromBase(baseBranch: string, baseRemote?: string): Promise<string[]>;
 
   /**
    * Get the name of the current local branch.
@@ -204,8 +204,7 @@ export function createGitSourceControl(repositoryPath: string): GitRepository {
 
   async function findRemoteFromUrl(remoteUrl: string) {
     const remotes = splitStdoutLines(await execGit(["remote", `--v`], { repositoryPath }));
-    console.log(remotes);
-    return remotes.find((remote) => remote.includes(remoteUrl))?.split(" ")[0];
+    return remotes.find((remote) => remote.includes(remoteUrl))?.split("\t")[0];
   }
 
   async function getCurrentBranch() {


### PR DESCRIPTION
fix #330

This allows to always know which remote to call regardless of what the user has configured from the base branch remote in a fork