### PR TITLE
Fix bumping package with only none changes

### DIFF
--- a/.chronus/changes/fix-none-bump-2025-3-22-18-36-58.md
+++ b/.chronus/changes/fix-none-bump-2025-3-22-18-36-58.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: breaking, feature, fix, internal
+changeKind: fix
+packages:
+  - "@chronus/chronus"
+---
+
+Fix bumping package with only `none` changes created empty changelog entry

--- a/packages/chronus/src/cli/cli.ts
+++ b/packages/chronus/src/cli/cli.ts
@@ -1,3 +1,4 @@
+import { readFile } from "node:fs/promises";
 import "source-map-support/register.js";
 import yargs from "yargs";
 import { resolvePath } from "../utils/path-utils.js";
@@ -13,6 +14,7 @@ import { withErrors, withErrorsAndReporter } from "./utils.js";
 
 export const DEFAULT_PORT = 3000;
 
+const pkg = JSON.parse(await readFile(resolvePath(import.meta.dirname, "../../package.json"), "utf8"));
 const filteringOptions = {
   only: {
     type: "string",
@@ -31,6 +33,7 @@ async function main() {
     .scriptName("chronus")
     .strict()
     .help()
+    .version(pkg.version)
     .parserConfiguration({
       "greedy-arrays": false,
       "boolean-negation": false,

--- a/packages/chronus/src/cli/commands/bump-versions.ts
+++ b/packages/chronus/src/cli/commands/bump-versions.ts
@@ -1,7 +1,6 @@
 import pc from "picocolors";
 import { isCI } from "std-env";
-import { updatePackageVersions } from "../../apply-release-plan/apply-release-plan.js";
-import { applyReleasePlan } from "../../apply-release-plan/index.js";
+import { applyReleasePlan, updatePackageVersions } from "../../apply-release-plan/apply-release-plan.js";
 import { readChangeDescriptions } from "../../change/read.js";
 import { getPrereleaseVersionActions } from "../../prerelease-versioning/index.js";
 import { assembleReleasePlan } from "../../release-plan/assemble-release-plan.js";

--- a/packages/chronus/src/release-plan/assemble-release-plan.test.ts
+++ b/packages/chronus/src/release-plan/assemble-release-plan.test.ts
@@ -120,6 +120,14 @@ describe("Assemble Release Plan", () => {
         });
       });
     });
+
+    it("doesn't include action if package only has none changes", () => {
+      const workspace: Workspace = mkWorkspace([mkPkg("pkg-a", {})]);
+      const plan = assembleReleasePlan([mkChange(["pkg-a"], "none")], createChronusWorkspace(workspace, baseConfig), {
+        only: ["pkg-a"],
+      });
+      expect(plan.actions).toHaveLength(0);
+    });
   });
 
   describe("lockStepVersioning", () => {

--- a/packages/chronus/src/release-plan/assemble-release-plan.ts
+++ b/packages/chronus/src/release-plan/assemble-release-plan.ts
@@ -60,17 +60,19 @@ export function assembleReleasePlan(
     exclude: options?.exclude,
   });
 
-  const actions = [...internalActions.values()].map((incompleteRelease): ReleaseAction => {
-    return {
-      ...incompleteRelease,
-      newVersion: getNewVersion(incompleteRelease),
-      changes: changes.filter(
-        (change) =>
-          change.changeKind.versionType !== "none" &&
-          change.packages.some((pkgName) => pkgName === incompleteRelease.packageName),
-      ),
-    };
-  });
+  const actions = [...internalActions.values()]
+    .filter((x) => x.type !== "none")
+    .map((incompleteRelease): ReleaseAction => {
+      return {
+        ...incompleteRelease,
+        newVersion: getNewVersion(incompleteRelease),
+        changes: changes.filter(
+          (change) =>
+            change.changeKind.versionType !== "none" &&
+            change.packages.some((pkgName) => pkgName === incompleteRelease.packageName),
+        ),
+      };
+    });
 
   return {
     changes: changeApplications,

--- a/packages/chronus/src/release-plan/types.ts
+++ b/packages/chronus/src/release-plan/types.ts
@@ -3,7 +3,7 @@ import type { VersionType } from "../types.js";
 
 export interface ReleaseAction {
   readonly packageName: string;
-  readonly type: VersionType;
+  readonly type: Omit<VersionType, "none">;
   readonly oldVersion: string;
   readonly newVersion: string;
   readonly changes: ChangeDescription[];


### PR DESCRIPTION
Packages that only had internal changelogs(versionType: none) would try to be bumped to the same version causing an extra entry in the changelog