### PR TITLE
Bump min Node to 22 and enforce no oxlint warnings

### DIFF
--- a/.chronus/changes/bump-min-node-22-2026-6-26-10-52-0.md
+++ b/.chronus/changes/bump-min-node-22-2026-6-26-10-52-0.md
@@ -1,0 +1,10 @@
+---
+# Change versionKind to one of: breaking, feature, fix, internal
+changeKind: feature
+packages:
+  - "@chronus/chronus"
+  - "@chronus/github"
+  - "@chronus/github-pr-commenter"
+---
+
+Bump minimum supported Node.js version to 22

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "watch": "tsc --build ./tsconfig.ws.json --watch",
     "build": "pnpm -r run build",
     "clean": "pnpm -r run clean && rimraf **/.temp/",
-    "lint": "oxlint",
+    "lint": "oxlint --max-warnings=0",
     "format": "oxfmt",
     "format:check": "oxfmt --check",
     "cspell": "cspell --no-progress ."
@@ -41,7 +41,7 @@
     "vitest": "catalog:"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "packageManager": "pnpm@11.9.0"
 }

--- a/packages/chronus/package.json
+++ b/packages/chronus/package.json
@@ -73,6 +73,6 @@
     "vitest": "catalog:"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   }
 }

--- a/packages/github-pr-commenter/package.json
+++ b/packages/github-pr-commenter/package.json
@@ -45,6 +45,6 @@
     "vite-bundle-visualizer": "catalog:"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   }
 }

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -54,6 +54,6 @@
     "typescript": "catalog:"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   }
 }

--- a/packages/registry-mock/package.json
+++ b/packages/registry-mock/package.json
@@ -39,6 +39,6 @@
     "typescript": "catalog:"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   }
 }


### PR DESCRIPTION
## Summary

- **Enforce no lint warnings in CI**: root `lint` script now runs `oxlint --max-warnings=0` (matching the per-package scripts), so warnings can no longer slip through the root `lint` CI job.
- **Bump minimum Node.js version to 22**: updated `engines.node` from `>=20.0.0` to `>=22.0.0` in the root and all packages. Node 20 is EOL and CI already runs Node 24.

## Notes

- The format check already exists as the dedicated `format` job in `ci.yml` (`pnpm run format:check`) — no `consistency.yml`, nothing to add there.
- Changeset added for the three published packages (`feature`).