### PR TITLE
Add official @chronus/action GitHub Action for release automation

### DIFF
--- a/.chronus/changes/add-github-action-2026-7-3-9-49-0.md
+++ b/.chronus/changes/add-github-action-2026-7-3-9-49-0.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: breaking, feature, fix, internal
+changeKind: feature
+packages:
+  - "@chronus/chronus"
+---
+
+Add official `@chronus/action` GitHub Action to maintain a "Version Packages" pull request, and export the `ReleasePlan` and `ReleaseAction` types from `@chronus/chronus`

--- a/.github/workflows/release-action.yml
+++ b/.github/workflows/release-action.yml
@@ -1,0 +1,32 @@
+name: Release Action
+
+# Publishes the bundled @chronus/action to its release refs (tag + major-line branch).
+# The built dist/ is gitignored on main and only force-committed onto these refs, mirroring
+# how changesets/action distributes its build.
+on:
+  workflow_dispatch: {}
+
+concurrency: ${{ github.workflow }}
+
+permissions:
+  contents: write # to push the release tag and major-line branch
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup
+
+      - run: pnpm install
+        name: Install dependencies
+
+      - run: pnpm build
+        name: Build
+
+      - run: pnpm tsx packages/action/scripts/release.ts
+        name: Push release refs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/action/README.md
+++ b/packages/action/README.md
@@ -1,0 +1,71 @@
+# @chronus/action
+
+Official GitHub Action to automate [chronus](https://github.com/timotheeguerin/chronus) releases.
+
+It maintains a **Version Packages** pull request: when changes land on your default branch it runs
+`chronus version`, bumps versions, updates changelogs, and opens (or updates) a draft pull request
+with the result. Merging that pull request releases the new versions.
+
+> This iteration covers the **version pull request** flow only. Publishing is still done with the
+> CLI. See the [GitHub Action guide](https://timotheeguerin.github.io/chronus/guides/github-action/)
+> for full documentation.
+
+## Usage
+
+```yaml
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+      - run: npm ci
+      - uses: timotheeguerin/chronus/packages/action@action-v1
+```
+
+## Inputs
+
+| Input            | Default                    | Description                                          |
+| ---------------- | -------------------------- | ---------------------------------------------------- |
+| `version`        | `npx chronus version`      | Command used to bump versions and update changelogs. |
+| `cwd`            | workspace root             | Working directory the action runs in.                |
+| `commit-message` | `Bump versions`            | Message used for the version bump commit.            |
+| `pr-title`       | `Release changes`          | Title of the version pull request.                   |
+| `pr-body`        | rendered release plan      | Body of the version pull request.                    |
+| `branch`         | `chronus/version-packages` | Branch the version changes are pushed to.            |
+| `base`           | repository default branch  | Base branch the pull request targets.                |
+| `token`          | `${{ github.token }}`      | GitHub token used to create/update the pull request. |
+
+## Outputs
+
+| Output          | Description                                         |
+| --------------- | --------------------------------------------------- |
+| `hasChangesets` | Whether there were pending changes to release.      |
+| `prNumber`      | Number of the created/updated version pull request. |
+| `prBranch`      | Branch the version changes were pushed to.          |
+
+## Development
+
+The action is bundled into a single standalone `dist/index.js` that is committed to the repository
+so it can run directly from a git ref. Rebuild it with:
+
+```bash
+pnpm --filter @chronus/action build
+```
+
+CI verifies the committed `dist/` is up to date.

--- a/packages/action/action.yml
+++ b/packages/action/action.yml
@@ -1,0 +1,50 @@
+name: Chronus Release
+description: Automate chronus releases by maintaining a "Version Packages" pull request.
+author: Microsoft
+
+branding:
+  icon: package
+  color: purple
+
+inputs:
+  version:
+    description: Command used to bump versions and update changelogs.
+    required: false
+    default: npx chronus version
+  cwd:
+    description: Working directory the action runs in. Defaults to the workspace root.
+    required: false
+  commit-message:
+    description: Message used for the version bump commit.
+    required: false
+    default: Bump versions
+  pr-title:
+    description: Title of the version pull request.
+    required: false
+    default: Release changes
+  pr-body:
+    description: Body of the version pull request. Defaults to a rendered summary of the release plan.
+    required: false
+  branch:
+    description: Branch the version changes are pushed to.
+    required: false
+    default: chronus/version-packages
+  base:
+    description: Base branch the pull request targets. Defaults to the repository default branch.
+    required: false
+  token:
+    description: GitHub token used to create/update the pull request.
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  hasChangesets:
+    description: Whether there were pending changes to release.
+  prNumber:
+    description: Number of the created/updated version pull request.
+  prBranch:
+    description: Branch the version changes were pushed to.
+
+runs:
+  using: node20
+  main: dist/index.js

--- a/packages/action/package.json
+++ b/packages/action/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@chronus/action",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Official GitHub Action to automate chronus releases",
+  "keywords": [
+    "change",
+    "changelog",
+    "chronus",
+    "github",
+    "github-action",
+    "monorepo"
+  ],
+  "homepage": "https://github.com/timotheeguerin/chronus#readme",
+  "bugs": "https://github.com/timotheeguerin/chronus/issues",
+  "license": "MIT",
+  "author": "Microsoft",
+  "repository": "timotheeguerin/chronus.git",
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "clean": "rimraf dist/ .temp/",
+    "lint": "oxlint --max-warnings=0",
+    "lint:fix": "oxlint --fix",
+    "test": "vitest run",
+    "test:watch": "vitest -w"
+  },
+  "dependencies": {
+    "@actions/core": "catalog:",
+    "@actions/exec": "catalog:",
+    "@actions/github": "catalog:",
+    "@chronus/chronus": "workspace:*",
+    "octokit": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "rimraf": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vite-bundle-visualizer": "catalog:"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  }
+}

--- a/packages/action/scripts/release.ts
+++ b/packages/action/scripts/release.ts
@@ -1,0 +1,57 @@
+import { Buffer } from "node:buffer";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/* eslint-disable no-console */
+
+// Release the bundled GitHub Action the way changesets/action does: the built `dist/` is
+// gitignored on the source branch and only force-committed onto the release refs consumers use.
+// This creates a detached commit that includes packages/action/dist and pushes it to:
+//   - an exact version tag:       action-v<version>
+//   - a moving major-line branch: action-v<major>   (e.g. action-v1)
+// Consumers then reference: timotheeguerin/chronus/packages/action@action-v1
+
+const actionDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = resolve(actionDir, "..", "..");
+const pkg = JSON.parse(readFileSync(resolve(actionDir, "package.json"), "utf8"));
+
+const version: string = pkg.version;
+const major = version.split(".")[0];
+const exactTag = `action-v${version}`;
+const majorBranch = `action-v${major}`;
+const isPrerelease = version.includes("-");
+
+const token = process.env.GITHUB_TOKEN;
+if (!token) {
+  throw new Error("GITHUB_TOKEN is required");
+}
+
+// Authenticate the push without relying on the checkout's persisted credentials so this works
+// regardless of the token used to check out the repository.
+const basic = Buffer.from(`x-access-token:${token}`).toString("base64");
+const gitEnv = {
+  ...process.env,
+  GIT_CONFIG_COUNT: "1",
+  GIT_CONFIG_KEY_0: "http.https://github.com/.extraheader",
+  GIT_CONFIG_VALUE_0: `AUTHORIZATION: basic ${basic}`,
+};
+
+function git(args: string[], env?: NodeJS.ProcessEnv): void {
+  execFileSync("git", args, { cwd: repoRoot, stdio: "inherit", env });
+}
+
+console.log(`Releasing @chronus/action as ${exactTag} (branch ${majorBranch})`);
+
+git(["checkout", "--detach"]);
+git(["add", "--force", "packages/action/dist"]);
+git(["-c", "user.email=chronus@github.com", "-c", "user.name=Chronus Bot", "commit", "-m", exactTag]);
+git(["tag", "-a", exactTag, "-m", exactTag]);
+
+git(["push", "origin", `refs/tags/${exactTag}`], gitEnv);
+if (!isPrerelease) {
+  git(["push", "--force", "origin", `HEAD:refs/heads/${majorBranch}`], gitEnv);
+}
+
+console.log("Done");

--- a/packages/action/src/index.ts
+++ b/packages/action/src/index.ts
@@ -1,0 +1,130 @@
+import * as core from "@actions/core";
+import * as exec from "@actions/exec";
+import * as github from "@actions/github";
+import {
+  NodeChronusHost,
+  renderReleasePlanAsMarkdown,
+  resolveCurrentReleasePlan,
+  type ReleasePlan,
+} from "@chronus/chronus";
+
+interface ActionInputs {
+  readonly versionCommand: string;
+  readonly cwd: string;
+  readonly commitMessage: string;
+  readonly prTitle: string;
+  readonly prBody: string | undefined;
+  readonly branch: string;
+  readonly base: string;
+  readonly token: string;
+}
+
+const gitUserName = "Chronus Bot";
+const gitUserEmail = "chronus@github.com";
+
+function getInputs(): ActionInputs {
+  const defaultBranch = (github.context.payload.repository as { default_branch?: string } | undefined)?.default_branch;
+  return {
+    versionCommand: core.getInput("version") || "npx chronus version",
+    cwd: core.getInput("cwd") || process.cwd(),
+    commitMessage: core.getInput("commit-message") || "Bump versions",
+    prTitle: core.getInput("pr-title") || "Release changes",
+    prBody: core.getInput("pr-body") || undefined,
+    branch: core.getInput("branch") || "chronus/version-packages",
+    base: core.getInput("base") || defaultBranch || "main",
+    token: core.getInput("token") || process.env.GITHUB_TOKEN || "",
+  };
+}
+
+async function git(args: string[], cwd: string): Promise<void> {
+  await exec.exec("git", args, { cwd });
+}
+
+async function hasPendingWorkingTreeChanges(cwd: string): Promise<boolean> {
+  const { stdout } = await exec.getExecOutput("git", ["status", "--porcelain"], { cwd, silent: true });
+  return stdout.trim() !== "";
+}
+
+async function run(): Promise<void> {
+  const inputs = getInputs();
+  if (!inputs.token) {
+    throw new Error("No GitHub token provided. Set the `token` input or the GITHUB_TOKEN environment variable.");
+  }
+
+  const plan = await resolveCurrentReleasePlan(NodeChronusHost, inputs.cwd);
+  if (plan.actions.length === 0) {
+    core.info("No pending changes found. Nothing to version.");
+    core.setOutput("hasChangesets", false);
+    return;
+  }
+  core.setOutput("hasChangesets", true);
+  core.info(`Found ${plan.actions.length} package(s) to bump. Running version command.`);
+
+  await exec.exec(inputs.versionCommand, undefined, { cwd: inputs.cwd });
+
+  if (!(await hasPendingWorkingTreeChanges(inputs.cwd))) {
+    core.info("Version command produced no file changes. Skipping PR creation.");
+    return;
+  }
+
+  await commitAndPush(inputs);
+  await createOrUpdatePullRequest(inputs, plan);
+}
+
+async function commitAndPush(inputs: ActionInputs): Promise<void> {
+  const { cwd, branch, commitMessage } = inputs;
+  await git(["config", "user.name", gitUserName], cwd);
+  await git(["config", "user.email", gitUserEmail], cwd);
+  await git(["add", "-A"], cwd);
+  await git(["commit", "-m", commitMessage], cwd);
+  await git(["push", "origin", `HEAD:refs/heads/${branch}`, "--force"], cwd);
+}
+
+async function createOrUpdatePullRequest(inputs: ActionInputs, plan: ReleasePlan): Promise<void> {
+  const { owner, repo } = github.context.repo;
+  const octokit = github.getOctokit(inputs.token);
+  const body = inputs.prBody ?? (await renderReleasePlanAsMarkdown(plan));
+
+  const existing = await octokit.rest.pulls.list({
+    owner,
+    repo,
+    head: `${owner}:${inputs.branch}`,
+    base: inputs.base,
+    state: "open",
+  });
+
+  const existingPr = existing.data[0];
+  if (existingPr) {
+    core.info(`Updating existing pull request #${existingPr.number}.`);
+    await octokit.rest.pulls.update({
+      owner,
+      repo,
+      pull_number: existingPr.number,
+      title: inputs.prTitle,
+      body,
+    });
+    setPrOutputs(existingPr.number, inputs.branch);
+  } else {
+    core.info(`Creating draft pull request from ${inputs.branch} into ${inputs.base}.`);
+    const created = await octokit.rest.pulls.create({
+      owner,
+      repo,
+      head: inputs.branch,
+      base: inputs.base,
+      title: inputs.prTitle,
+      body,
+      // Draft works around orgs that block Actions from triggering workflows on non-draft PRs.
+      draft: true,
+    });
+    setPrOutputs(created.data.number, inputs.branch);
+  }
+}
+
+function setPrOutputs(prNumber: number, branch: string): void {
+  core.setOutput("prNumber", prNumber);
+  core.setOutput("prBranch", branch);
+}
+
+run().catch((error) => {
+  core.setFailed(error instanceof Error ? error.message : String(error));
+});

--- a/packages/action/tsconfig.build.json
+++ b/packages/action/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "references": [],
+  "include": ["src"],
+  "exclude": ["**/*.test.*", "test/**/*"]
+}

--- a/packages/action/tsconfig.json
+++ b/packages/action/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "tsBuildInfoFile": ".temp/.tsbuildinfo"
+  }
+}

--- a/packages/action/vite.config.ts
+++ b/packages/action/vite.config.ts
@@ -1,0 +1,31 @@
+import { builtinModules } from "module";
+import path from "path";
+
+import { defineConfig } from "vite";
+
+// Bundle EVERYTHING (all npm deps + workspace deps) into a single standalone file so the
+// action can run directly from a git ref with no install step. Only Node builtins stay external.
+// A single-entry `lib` build already emits one file (vite inlines dynamic imports), so no extra
+// code-splitting option is required.
+const nodeBuiltins = new Set([...builtinModules, ...builtinModules.map((m) => `node:${m}`)]);
+
+export default defineConfig({
+  build: {
+    target: "node20",
+    outDir: "dist",
+    ssr: true,
+    minify: false,
+    lib: {
+      entry: path.resolve(__dirname, "src/index.ts"),
+      fileName: () => "index.js",
+      formats: ["es"],
+    },
+    rollupOptions: {
+      external: (source: string): boolean => nodeBuiltins.has(source) || source.startsWith("node:"),
+    },
+  },
+  ssr: {
+    target: "node",
+    noExternal: true,
+  },
+});

--- a/packages/action/vitest.config.ts
+++ b/packages/action/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig, mergeConfig } from "vitest/config";
+
+import { defaultVitestConfig } from "../../vitest.config.js";
+
+export default mergeConfig(defaultVitestConfig, defineConfig({}));

--- a/packages/chronus/src/index.ts
+++ b/packages/chronus/src/index.ts
@@ -1,6 +1,7 @@
 export type { AreaStatus, ChangeArea, ChangeStatus, PackageStatus } from "./change/find.js";
 export { getWorkspaceStatus } from "./change/get-workspace-status.js";
 export { renderReleasePlanAsMarkdown, resolveCurrentReleasePlan } from "./release-plan/index.js";
+export type { ReleaseAction, ReleasePlan } from "./release-plan/index.js";
 export { NodeChronusHost } from "./utils/node-host.js";
 export { loadChronusWorkspace } from "./workspace/index.js";
 export type { ChronusWorkspace } from "./workspace/types.js";

--- a/packages/chronus/src/release-plan/index.ts
+++ b/packages/chronus/src/release-plan/index.ts
@@ -1,4 +1,5 @@
 export { assembleReleasePlan } from "./assemble-release-plan.js";
 export { resolveCurrentReleasePlan } from "./current.js";
 export { renderReleasePlanAsMarkdown } from "./markdown.js";
+export type { ReleaseAction, ReleasePlan } from "./types.js";
 export type * from "./types.js";

--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -29,6 +29,7 @@ export default defineConfig({
             { label: "Change Kinds", slug: "guides/change-kinds" },
             { label: "Changed Files Filter", slug: "guides/changed-files-filter" },
             { label: "Changelog Generator", slug: "guides/changelog-generator" },
+            { label: "GitHub Action", slug: "guides/github-action" },
             { label: "Prereleases", slug: "guides/prerelease" },
             { label: "Supported Environments", slug: "guides/supported-environments" },
             { label: "Version Policies", slug: "guides/version-policies" },

--- a/packages/website/src/content/docs/guides/github-action.md
+++ b/packages/website/src/content/docs/guides/github-action.md
@@ -1,0 +1,90 @@
+---
+title: GitHub Action
+description: Automate chronus releases with a maintained "Version Packages" pull request.
+---
+
+Chronus ships a first-party GitHub Action that keeps a **Version Packages** pull request up to
+date for you. Whenever changes land on your default branch, the action runs `chronus version`,
+applies the pending change descriptions, bumps versions, updates changelogs, and opens (or
+updates) a pull request with the result. Merging that pull request is what actually releases the
+new versions.
+
+:::note
+This iteration of the action covers the **version pull request** flow only. Publishing
+(`chronus pack` / `chronus publish` and GitHub releases) is still done with the CLI — see the
+[CLI reference](/reference/cli). Automated publishing from the action is planned.
+:::
+
+## Usage
+
+Add a workflow that runs on pushes to your default branch:
+
+```yaml
+# .github/workflows/release.yml
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Needed so chronus can compare against the base branch
+
+      # Install your dependencies and make the `chronus` CLI available, e.g. pnpm/npm install.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+      - run: npm ci
+
+      - uses: timotheeguerin/chronus/packages/action@action-v1
+```
+
+The action pushes the version changes to a branch (default `chronus/version-packages`) and opens a
+**draft** pull request. The pull request is opened as a draft on purpose: some organizations block
+Actions from triggering other workflows on regular pull requests, and using a draft works around
+that restriction. Mark it "Ready for review" (or merge it) when you want to release.
+
+## Inputs
+
+| Input            | Default                    | Description                                          |
+| ---------------- | -------------------------- | ---------------------------------------------------- |
+| `version`        | `npx chronus version`      | Command used to bump versions and update changelogs. |
+| `cwd`            | workspace root             | Working directory the action runs in.                |
+| `commit-message` | `Bump versions`            | Message used for the version bump commit.            |
+| `pr-title`       | `Release changes`          | Title of the version pull request.                   |
+| `pr-body`        | rendered release plan      | Body of the version pull request.                    |
+| `branch`         | `chronus/version-packages` | Branch the version changes are pushed to.            |
+| `base`           | repository default branch  | Base branch the pull request targets.                |
+| `token`          | `${{ github.token }}`      | GitHub token used to create/update the pull request. |
+
+## Outputs
+
+| Output          | Description                                         |
+| --------------- | --------------------------------------------------- |
+| `hasChangesets` | Whether there were pending changes to release.      |
+| `prNumber`      | Number of the created/updated version pull request. |
+| `prBranch`      | Branch the version changes were pushed to.          |
+
+## How it works
+
+1. The action resolves the current release plan from your pending change descriptions.
+2. If there are no pending changes, it does nothing and sets `hasChangesets` to `false`.
+3. Otherwise it runs the `version` command, commits the result, force-pushes it to `branch`, and
+   opens or updates a draft pull request targeting `base`.
+
+## Versioning
+
+Pin the action to a release ref such as `@action-v1` (a moving major-line branch) or an exact
+`@action-v1.0.0` tag. The action is bundled into a single `dist/index.js` that is **not** committed
+to `main`; it is built and force-committed onto the release refs by the `Release Action` workflow.
+This keeps the source tree clean while still letting the action run directly from a git ref.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,12 @@ settings:
 
 catalogs:
   default:
+    '@actions/core':
+      specifier: ^1.11.1
+      version: 1.11.1
+    '@actions/exec':
+      specifier: ^1.1.1
+      version: 1.1.1
     '@actions/github':
       specifier: ^9.0.0
       version: 9.1.1
@@ -176,6 +182,40 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@types/node@26.0.0)(@vitest/ui@4.1.9)(vite@8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
+
+  packages/action:
+    dependencies:
+      '@actions/core':
+        specifier: 'catalog:'
+        version: 1.11.1
+      '@actions/exec':
+        specifier: 'catalog:'
+        version: 1.1.1
+      '@actions/github':
+        specifier: 'catalog:'
+        version: 9.1.1
+      '@chronus/chronus':
+        specifier: workspace:*
+        version: link:../chronus
+      octokit:
+        specifier: 'catalog:'
+        version: 5.0.5
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 26.0.0
+      rimraf:
+        specifier: 'catalog:'
+        version: 6.1.3
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
+      vite-bundle-visualizer:
+        specifier: 'catalog:'
+        version: 1.2.1(rolldown@1.1.3)
 
   packages/chronus:
     dependencies:
@@ -369,11 +409,23 @@ importers:
 
 packages:
 
+  '@actions/core@1.11.1':
+    resolution: {integrity: sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==}
+
+  '@actions/exec@1.1.1':
+    resolution: {integrity: sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==}
+
   '@actions/github@9.1.1':
     resolution: {integrity: sha512-tL5JbYOBZHc0ngEnCsaDcryUizIUIlQyIMwy1Wkx93H5HzbBJ7TbiPx2PnFjBwZW0Vh05JmfFZhecE6gglYegA==}
 
+  '@actions/http-client@2.2.3':
+    resolution: {integrity: sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==}
+
   '@actions/http-client@3.0.2':
     resolution: {integrity: sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==}
+
+  '@actions/io@1.1.3':
+    resolution: {integrity: sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==}
 
   '@astrojs/compiler-binding-darwin-arm64@0.2.3':
     resolution: {integrity: sha512-sJIHeL1ONXEBLob8ZaXfmX6iCftUno08G/cMXj2FJnL0xNbHuELcEq1mjxHVFHNgUYu4P7xJNm2mpc0zUEPoKw==}
@@ -974,6 +1026,10 @@ packages:
 
   '@expressive-code/plugin-text-markers@0.43.1':
     resolution: {integrity: sha512-JWf8wdbZSNoGY4TFv3lmt3/NNDaCP7iYL6rRYD05g8YYjKL62hKUHLl5+B47+v0+bqbuMhXDN7qz2wywFUvMkg==}
+
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -4515,6 +4571,10 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
+    engines: {node: '>=14.0'}
+
   undici@6.27.0:
     resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
@@ -4879,6 +4939,15 @@ packages:
 
 snapshots:
 
+  '@actions/core@1.11.1':
+    dependencies:
+      '@actions/exec': 1.1.1
+      '@actions/http-client': 2.2.3
+
+  '@actions/exec@1.1.1':
+    dependencies:
+      '@actions/io': 1.1.3
+
   '@actions/github@9.1.1':
     dependencies:
       '@actions/http-client': 3.0.2
@@ -4889,10 +4958,17 @@ snapshots:
       '@octokit/request-error': 7.1.0
       undici: 6.27.0
 
+  '@actions/http-client@2.2.3':
+    dependencies:
+      tunnel: 0.0.6
+      undici: 5.29.0
+
   '@actions/http-client@3.0.2':
     dependencies:
       tunnel: 0.0.6
       undici: 6.27.0
+
+  '@actions/io@1.1.3': {}
 
   '@astrojs/compiler-binding-darwin-arm64@0.2.3':
     optional: true
@@ -5489,6 +5565,8 @@ snapshots:
   '@expressive-code/plugin-text-markers@0.43.1':
     dependencies:
       '@expressive-code/core': 0.43.1
+
+  '@fastify/busboy@2.1.1': {}
 
   '@img/colour@1.1.0': {}
 
@@ -6245,7 +6323,7 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 24.13.2
+      '@types/node': 26.0.0
 
   '@types/semver@7.7.1': {}
 
@@ -9590,6 +9668,10 @@ snapshots:
   undici-types@7.18.2: {}
 
   undici-types@8.3.0: {}
+
+  undici@5.29.0:
+    dependencies:
+      '@fastify/busboy': 2.1.1
 
   undici@6.27.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,8 @@ ignoredBuiltDependencies:
   - sharp
 
 catalog:
+  "@actions/core": "^1.11.1"
+  "@actions/exec": "^1.1.1"
   "@actions/github": "^9.0.0"
   "@astrojs/starlight": "0.41.0"
   "@octokit/graphql": "^9.0.1"


### PR DESCRIPTION
Closes #583 (version-PR flow).

## What
Adds a first-party, consumable GitHub Action (`@chronus/action`) that maintains a **"Version Packages"** pull request, à la `changesets/action`. On pushes to the default branch it resolves the release plan, runs `chronus version`, commits the bumped versions + changelogs, force-pushes to a branch, and opens/updates a **draft** PR.

Consumers use:
```yaml
- uses: timotheeguerin/chronus/packages/action@action-v1
```

## Scope
Version-PR flow only. Publishing (pack/publish/GitHub releases) is deferred; extension points are left in place.

## How it's built & distributed (changesets model)
- `packages/action` bundles into a single standalone `dist/index.js` (only Node builtins external).
- `dist/` is **gitignored on `main`** — not committed to source.
- `.github/workflows/release-action.yml` (`workflow_dispatch`) builds and runs `packages/action/scripts/release.ts`, which force-commits `packages/action/dist` onto:
  - exact tag `action-v<version>`
  - moving major-line branch `action-v<major>`

## Inputs / outputs
- Inputs: `version`, `cwd`, `commit-message`, `pr-title`, `pr-body`, `branch`, `base`, `token`.
- Outputs: `hasChangesets`, `prNumber`, `prBranch`.
- PR opened as **draft** (per #583 comment: works around orgs blocking Actions from triggering workflows on non-draft PRs).

## Other changes
- Export `ReleasePlan` / `ReleaseAction` types from `@chronus/chronus`.
- Add `@actions/core` + `@actions/exec` to the pnpm catalog.
- Docs guide (`guides/github-action`) + sidebar entry + package README.
- Changeset (feature, `@chronus/chronus`).

## Notes
- `@chronus/action` is private (not published to npm); it's consumed via git ref.
