### PR TITLE
Add `packageCommitCount` prerelease template variable

### DIFF
--- a/.chronus/changes/prerelease-package-commit-count-2026-7-3-20-49-0.md
+++ b/.chronus/changes/prerelease-package-commit-count-2026-7-3-20-49-0.md
@@ -1,0 +1,11 @@
+---
+changeKind: feature
+packages:
+  - "@chronus/chronus"
+---
+
+Add `{packageCommitCount}` prerelease template variable that counts the commits touching a package's folder. Unlike `{changeCount}`, this value is monotonic (a revert is a new commit), so reverting a change and deleting its change entry no longer collides with an already published prerelease version and blocks new prereleases.
+
+```bash
+chronus version --prerelease "{nextVersion}-dev.{packageCommitCount}"
+```

--- a/packages/chronus/src/cli/commands/bump-versions.ts
+++ b/packages/chronus/src/cli/commands/bump-versions.ts
@@ -6,6 +6,7 @@ import { readChangeDescriptions } from "../../change/read.js";
 import { getPrereleaseVersionActions } from "../../prerelease-versioning/index.js";
 import { assembleReleasePlan } from "../../release-plan/assemble-release-plan.js";
 import type { ReleasePlan } from "../../release-plan/types.js";
+import { createGitSourceControl } from "../../source-control/git.js";
 import type { ChronusHost } from "../../utils/host.js";
 import { NodeChronusHost } from "../../utils/node-host.js";
 import { loadChronusWorkspace } from "../../workspace/load.js";
@@ -59,7 +60,11 @@ async function bumpPrereleaseVersion(
   filters: { only?: string[]; exclude?: string[] } = {},
 ) {
   const changes = await readChangeDescriptions(host, workspace);
-  const versionActions = await getPrereleaseVersionActions(changes, workspace, prereleaseTemplate, filters);
+  const sourceControl = createGitSourceControl(workspace.path);
+  const versionActions = await getPrereleaseVersionActions(changes, workspace, prereleaseTemplate, {
+    ...filters,
+    sourceControl,
+  });
   const maxLength = workspace.packages.reduce((max, pkg) => Math.max(max, pkg.name.length), 0);
   for (const [pkgName, action] of versionActions) {
     log(`Bumping ${pc.magenta(pkgName.padEnd(maxLength))} to ${pc.cyan(action.newVersion)}`);

--- a/packages/chronus/src/prerelease-versioning/index.ts
+++ b/packages/chronus/src/prerelease-versioning/index.ts
@@ -1,1 +1,1 @@
-export { getPrereleaseVersionActions } from "./prerelease-versioning.js";
+export { getPrereleaseVersionActions, type PrereleaseVersionOptions } from "./prerelease-versioning.js";

--- a/packages/chronus/src/prerelease-versioning/prerelease-versioning.test.ts
+++ b/packages/chronus/src/prerelease-versioning/prerelease-versioning.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { ChangeDescription } from "../change/types.js";
 import { addNameToChangeKinds, defaultChangeKinds } from "../config/resolve.js";
 import type { ChronusResolvedConfig } from "../config/types.js";
+import type { GitRepository } from "../source-control/git.js";
 import type { VersionType } from "../types.js";
 import type { Package, PackageJson } from "../workspace-manager/types.js";
 import { createChronusWorkspace } from "../workspace/load.js";
@@ -96,5 +97,60 @@ describe("Assemble Release Plan", () => {
 
     expect(res.size).toBe(1);
     expect(res.get("pkg-a")?.newVersion).toBe("1.1.0-dev.1");
+  });
+
+  describe("interpolate packageCommitCount", () => {
+    function mkSourceControl(counts: Record<string, number>) {
+      return {
+        async getCommitCountForPath(path: string) {
+          const name = Object.keys(counts).find((n) => path.endsWith(`packages/${n}`));
+          return name ? counts[name] : 0;
+        },
+      } as unknown as GitRepository;
+    }
+
+    it("uses the per-package commit count as the suffix", async () => {
+      const res = await getPrereleaseVersionActions(
+        [mkChange(["pkg-a"], "minor")],
+        createChronusWorkspace(workspace, baseConfig),
+        "{nextVersion}-dev.{packageCommitCount}",
+        { sourceControl: mkSourceControl({ "pkg-a": 42, "pkg-b": 7, "pkg-c": 0 }) },
+      );
+
+      expect(res.get("pkg-a")?.newVersion).toBe("1.1.0-dev.42");
+      expect(res.get("pkg-b")?.newVersion).toBe("1.0.4-dev.7");
+      expect(res.get("pkg-c")?.newVersion).toBe("1.0.1-dev.0");
+    });
+
+    it("stays monotonic when a change entry is reverted/removed", async () => {
+      const ws = createChronusWorkspace(workspace, baseConfig);
+      // Two changes on pkg-a produce commit count 5.
+      const withTwoChanges = await getPrereleaseVersionActions(
+        [mkChange(["pkg-a"], "minor"), mkChange(["pkg-a"], "patch")],
+        ws,
+        "{nextVersion}-dev.{packageCommitCount}",
+        { sourceControl: mkSourceControl({ "pkg-a": 5 }) },
+      );
+      expect(withTwoChanges.get("pkg-a")?.newVersion).toBe("1.1.0-dev.5");
+
+      // A revert deletes one change entry but adds a commit -> commit count only grows.
+      const afterRevert = await getPrereleaseVersionActions(
+        [mkChange(["pkg-a"], "minor")],
+        ws,
+        "{nextVersion}-dev.{packageCommitCount}",
+        { sourceControl: mkSourceControl({ "pkg-a": 6 }) },
+      );
+      expect(afterRevert.get("pkg-a")?.newVersion).toBe("1.1.0-dev.6");
+    });
+
+    it("throws when the template needs a commit count but no source control is provided", async () => {
+      await expect(
+        getPrereleaseVersionActions(
+          [mkChange(["pkg-a"], "minor")],
+          createChronusWorkspace(workspace, baseConfig),
+          "{nextVersion}-dev.{packageCommitCount}",
+        ),
+      ).rejects.toThrow(/packageCommitCount/);
+    });
   });
 });

--- a/packages/chronus/src/prerelease-versioning/prerelease-versioning.ts
+++ b/packages/chronus/src/prerelease-versioning/prerelease-versioning.ts
@@ -3,24 +3,42 @@ import { inc, parse } from "semver";
 import type { VersionAction } from "../apply-release-plan/get-manifest-patch-request.js";
 import type { ChangeDescription } from "../change/types.js";
 import { assembleReleasePlan } from "../release-plan/assemble-release-plan.js";
+import type { GitRepository } from "../source-control/git.js";
 import { isPackageIncluded } from "../utils/misc-utils.js";
+import { resolvePath } from "../utils/path-utils.js";
 import type { ChronusWorkspace } from "../workspace/types.js";
+
+export interface PrereleaseVersionOptions {
+  readonly only?: string[];
+  readonly exclude?: string[];
+  /**
+   * Source control used to resolve `{packageCommitCount}`. Required when the template references it.
+   */
+  readonly sourceControl?: GitRepository;
+}
+
+/** Variable name that requires access to source control to be resolved. */
+const packageCommitCountVar = "packageCommitCount";
 
 /**
  *
  * @param changes Current changesets
  * @param workspace Chronus workspace
  * @param prereleaseTemplate Template for the prerelease version. The following variables are available:
- *  - changeCount
- *  - changeCountWithPatch
- *  - nextVersion
+ *  - changeCount: Number of change entries currently present for the package. Not monotonic (a
+ *    reverted/deleted change entry decreases it).
+ *  - changeCountWithPatch: changeCount plus the current patch number of the package.
+ *  - packageCommitCount: Number of commits reachable from HEAD that touched the package folder.
+ *    Monotonic (only grows), so it is not affected by reverts deleting change entries. Requires
+ *    `options.sourceControl` and the full git history to be available.
+ *  - nextVersion: The next version for the package if `chronus version` was run today.
  * @returns Map of each package and their prerelease version
  */
 export async function getPrereleaseVersionActions(
   changes: ChangeDescription[],
   workspace: ChronusWorkspace,
   prereleaseTemplate: string,
-  filters: { only?: string[]; exclude?: string[] } = {},
+  options: PrereleaseVersionOptions = {},
 ): Promise<Map<string, VersionAction>> {
   const releasePlan = assembleReleasePlan(changes, workspace);
 
@@ -38,15 +56,29 @@ export async function getPrereleaseVersionActions(
     }
   }
 
+  const needsCommitCount = prereleaseTemplate.includes(`{${packageCommitCountVar}}`);
+  if (needsCommitCount && options.sourceControl === undefined) {
+    throw new Error(
+      `Prerelease template uses {${packageCommitCountVar}} but no source control was provided to resolve it.`,
+    );
+  }
+
   const versionActions = new Map<string, VersionAction>();
-  for (const pkg of workspace.packages.filter((pkg) => isPackageIncluded(pkg, filters))) {
+  for (const pkg of workspace.packages.filter((pkg) => isPackageIncluded(pkg, options))) {
     const changeCount = changePerPackage.get(pkg.name) ?? 0;
     const action = releasePlan.actions.find((x) => x.packageName === pkg.name);
     const version = parse(pkg.version)!;
 
+    let packageCommitCount = 0;
+    if (needsCommitCount && options.sourceControl) {
+      const packagePath = resolvePath(workspace.path, pkg.relativePath);
+      packageCommitCount = await options.sourceControl.getCommitCountForPath(packagePath);
+    }
+
     const prereleaseVersion = interpolateTemplate(prereleaseTemplate, {
       changeCount,
       changeCountWithPatch: changeCount + version.patch,
+      packageCommitCount,
       nextVersion: action?.newVersion ?? inc(pkg.version, "patch")!,
     });
     versionActions.set(pkg.name, { newVersion: prereleaseVersion });
@@ -58,6 +90,7 @@ export async function getPrereleaseVersionActions(
 interface InterpolatePrereleaseVersionArgs {
   readonly changeCount: number;
   readonly changeCountWithPatch: number;
+  readonly packageCommitCount: number;
   readonly nextVersion: string;
 }
 

--- a/packages/chronus/src/source-control/git.test.ts
+++ b/packages/chronus/src/source-control/git.test.ts
@@ -211,4 +211,36 @@ describe("git", () => {
       expect(await git.listChangedFilesSince("main")).toEqual(["feat-1.ts", "feat-2.ts"]);
     });
   });
+
+  describe("getCommitCountForPath", () => {
+    async function addFileAndCommit(message: string, paths: string[]) {
+      for (const path of paths) {
+        await testDir.addFile(path);
+      }
+      await git.add(".");
+      await git.commit(message);
+    }
+
+    beforeEach(async () => {
+      await addFileAndCommit("c1: add pkg-a", ["packages/pkg-a/a.ts"]);
+      await addFileAndCommit("c2: add pkg-b", ["packages/pkg-b/b.ts"]);
+      await addFileAndCommit("c3: touch pkg-a again", ["packages/pkg-a/a2.ts"]);
+    });
+
+    it("counts only commits touching the given folder", async () => {
+      expect(await git.getCommitCountForPath("packages/pkg-a")).toBe(2);
+      expect(await git.getCommitCountForPath("packages/pkg-b")).toBe(1);
+    });
+
+    it("returns 0 for a path with no commits", async () => {
+      expect(await git.getCommitCountForPath("packages/pkg-does-not-exist")).toBe(0);
+    });
+
+    it("only grows when a commit reverts a previous one", async () => {
+      const before = await git.getCommitCountForPath("packages/pkg-a");
+      await execAsync("git", ["revert", "--no-edit", "HEAD"], { cwd });
+      const after = await git.getCommitCountForPath("packages/pkg-a");
+      expect(after).toBe(before + 1);
+    });
+  });
 });

--- a/packages/chronus/src/source-control/git.ts
+++ b/packages/chronus/src/source-control/git.ts
@@ -86,6 +86,20 @@ export interface GitRepository {
    * Return the commit ids that added the given files.
    */
   getCommitsThatAddFiles(files: string[]): Promise<Record<string, string>>;
+
+  /**
+   * Return the number of commits reachable from HEAD that touched the given path.
+   * This count only ever grows as new commits are added (reverts are new commits), making it
+   * suitable as a monotonic prerelease counter.
+   *
+   * Note: requires the full history to be available (e.g. `fetch-depth: 0` in CI). On a shallow
+   * clone the count will be limited to the commits present in the clone.
+   * ```bash
+   * git rev-list --count HEAD -- <path>
+   * ```
+   * @param path Path (file or directory) to count commits for. Can be absolute or relative to the repository.
+   */
+  getCommitCountForPath(path: string): Promise<number>;
 }
 
 export class GitError extends Error {
@@ -125,6 +139,7 @@ export function createGitSourceControl(repositoryPath: string): GitRepository {
     listChangedFilesSince,
     getCurrentBranch,
     getCommitsThatAddFiles,
+    getCommitCountForPath,
   };
 
   async function getRepoRoot(): Promise<string> {
@@ -283,6 +298,12 @@ export function createGitSourceControl(repositoryPath: string): GitRepository {
       // eslint-disable-next-line no-constant-condition
     } while (true);
     return commits;
+  }
+
+  async function getCommitCountForPath(path: string): Promise<number> {
+    const result = await execGit(["rev-list", "--count", "HEAD", "--", path], { repositoryPath });
+    const count = Number.parseInt(trimSingleLine(result), 10);
+    return Number.isNaN(count) ? 0 : count;
   }
 
   async function deepenCloneBy({ by, repositoryPath }: { by: number; repositoryPath: string }) {

--- a/packages/website/src/content/docs/guides/prerelease.md
+++ b/packages/website/src/content/docs/guides/prerelease.md
@@ -28,12 +28,31 @@ chronus version --prerelease "{nextVersion}-next.{changeCountWithPatch}"
 | `{nextVersion}`          | The next version number for that package if you were to run `chronus version` today |
 | `{changeCount}`          | The number of changes since the last release for that package                       |
 | `{changeCountWithPatch}` | The number of changes plus the current patch count of the package                   |
+| `{packageCommitCount}`   | The number of commits reachable from `HEAD` that touched the package folder         |
+
+## Choosing a suffix
+
+`{changeCount}` (and `{changeCountWithPatch}`) count the change entry files currently present for a
+package. This value is **not monotonic**: if a pull request reverts a commit and deletes its change
+entry, the count decreases and the computed prerelease version can collide with one already
+published, which prevents any new prerelease from being published until enough new changes are added
+to climb back past the previous number.
+
+Use `{packageCommitCount}` to avoid this. It counts commits that touched the package folder, which
+only ever grows (a revert is itself a new commit), so a deleted change entry never lowers it. It
+still only changes for packages that were actually modified, so untouched packages keep the same
+version and are not republished.
+
+> `{packageCommitCount}` requires the full git history to be available. In CI make sure to do a full
+> clone (for example `fetch-depth: 0` with `actions/checkout`); on a shallow clone the count is
+> limited to the commits present in the clone.
 
 ## Examples
 
 Given package `pkg-a` with independent version policy, currently at version `1.4.2` with 3 changes (2 minor, 1 patch) since the last release:
 
-| Template                                   | Resolved version |
-| ------------------------------------------ | ---------------- |
-| `{nextVersion}-dev.{changeCountWithPatch}` | `1.5.0-dev.5`    |
-| `{nextVersion}-dev.{changeCount}`          | `1.5.0-dev.3`    |
+| Template                                   | Resolved version                     |
+| ------------------------------------------ | ------------------------------------ |
+| `{nextVersion}-dev.{changeCountWithPatch}` | `1.5.0-dev.5`                        |
+| `{nextVersion}-dev.{changeCount}`          | `1.5.0-dev.3`                        |
+| `{nextVersion}-dev.{packageCommitCount}`   | `1.5.0-dev.<commits touching pkg-a>` |


### PR DESCRIPTION
## Problem

The default prerelease algorithm (`chronus version --prerelease`) uses `{nextVersion}-dev.{changeCountWithPatch}`, where `changeCount` is the number of change-entry files currently present for a package. This value is **not monotonic**: when a PR reverts a commit and deletes its change entry, the count decreases. The recomputed prerelease version then collides with one already published (and gets filtered out as "already published"), so **no new prerelease is published until enough new changes are added to climb back past the previous number**.

## Fix

Add a new prerelease template variable `{packageCommitCount}` = number of commits reachable from `HEAD` that touched the package folder (`git rev-list --count HEAD -- <path>`).

- **Monotonic** — a revert is itself a new commit, so the count only ever grows; a deleted change entry never lowers it.
- **Per-package** — only packages actually modified get a new number, so untouched packages keep the same version and are not republished (no "release everything on every commit").
- `{nextVersion}` still comes from the current change entries as before.

```bash
chronus version --prerelease "{nextVersion}-dev.{packageCommitCount}"
```

> Requires full git history (e.g. `fetch-depth: 0` in CI); on a shallow clone the count is limited to the commits present in the clone.

## Changes

- `source-control/git.ts`: new `getCommitCountForPath()` helper (+ integration tests incl. a revert-only-grows test).
- `prerelease-versioning.ts`: resolve `{packageCommitCount}`, threading a `GitRepository` through `PrereleaseVersionOptions`; clear error if the template uses it without source control.
- `cli/commands/bump-versions.ts`: pass a git source control when bumping prerelease versions.
- Docs: prerelease guide updated with the new variable and a "choosing a suffix" note.

## Tests

New unit tests cover the suffix value, monotonicity across a revert, and the missing-source-control error. Full suite: 245 passing.