### PR TITLE
fix: handle npm 12+ keyed publish --json output

### DIFF
--- a/.chronus/changes/fix-npm-publish-json-format-2026-7-16-11-23-0.md
+++ b/.chronus/changes/fix-npm-publish-json-format-2026-7-16-11-23-0.md
@@ -1,0 +1,10 @@
+---
+# Change versionKind to one of: breaking, feature, fix, internal
+changeKind: fix
+packages:
+  - "@chronus/chronus"
+---
+
+Fix `chronus publish` reporting `undefined` name/version and size with npm 12+
+
+npm 12 changed the `npm publish --json` output to be keyed by package name instead of a flat object. The publish result parsing now handles both the new keyed format and the legacy flat format.

--- a/packages/chronus/src/publish/normalize-npm-publish-result.test.ts
+++ b/packages/chronus/src/publish/normalize-npm-publish-result.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeNpmPublishResult } from "./publish-package.js";
+
+describe("normalizeNpmPublishResult", () => {
+  const flat = {
+    id: "pkg-a@1.0.0",
+    name: "pkg-a",
+    version: "1.0.0",
+    size: 142,
+    unpackedSize: 42,
+    shasum: "abc",
+    integrity: "sha512-xxx",
+  };
+
+  it("returns the flat/legacy object as-is", () => {
+    expect(normalizeNpmPublishResult(flat, "pkg-a")).toEqual(flat);
+  });
+
+  it("unwraps the keyed format (npm >=12) using the package name", () => {
+    const keyed = { "pkg-a": flat };
+    expect(normalizeNpmPublishResult(keyed, "pkg-a")).toEqual(flat);
+  });
+
+  it("falls back to the first entry of the keyed format when the name doesn't match", () => {
+    const keyed = { "pkg-a": flat };
+    expect(normalizeNpmPublishResult(keyed, "other")).toEqual(flat);
+  });
+
+  it("unwraps the keyed format without a package name hint", () => {
+    const keyed = { "pkg-a": flat };
+    expect(normalizeNpmPublishResult(keyed)).toEqual(flat);
+  });
+
+  it("returns null for null input", () => {
+    expect(normalizeNpmPublishResult(null)).toBeNull();
+  });
+
+  it("returns null for an empty object", () => {
+    expect(normalizeNpmPublishResult({})).toBeNull();
+  });
+});

--- a/packages/chronus/src/publish/publish-package.ts
+++ b/packages/chronus/src/publish/publish-package.ts
@@ -28,6 +28,31 @@ interface NpmPublishResult {
   readonly integrity: string;
 }
 
+/**
+ * Normalize the parsed JSON output of `npm publish --json`.
+ * npm >=12 (and pnpm) changed the output to be an object keyed by package name:
+ *   `{ "pkg-name": { id, name, version, size, unpackedSize, ... } }`
+ * while older versions returned the flat object directly:
+ *   `{ id, name, version, size, unpackedSize, ... }`
+ * This handles both shapes and returns the flat result (or `null` when it can't be resolved).
+ */
+export function normalizeNpmPublishResult(json: unknown, packageName?: string): NpmPublishResult | null {
+  if (json === null || typeof json !== "object") {
+    return null;
+  }
+  const record = json as Record<string, unknown>;
+  if (typeof record.version === "string") {
+    // Flat/legacy format.
+    return record as unknown as NpmPublishResult;
+  }
+  // Keyed format: prefer the entry matching the package name, otherwise take the first entry.
+  const entry = (packageName !== undefined ? record[packageName] : undefined) ?? Object.values(record)[0];
+  if (entry !== null && typeof entry === "object" && typeof (entry as NpmPublishResult).version === "string") {
+    return entry as NpmPublishResult;
+  }
+  return null;
+}
+
 async function isDir(path: string) {
   try {
     const s = await stat(path);
@@ -76,13 +101,13 @@ export async function publishPackageWithNpm(
   if (result.code !== 0) {
     return processError(pkg, result);
   }
-  const parsedResult: NpmPublishResult = getLastJsonObject(result.stdout.toString());
+  const parsedResult = normalizeNpmPublishResult(getLastJsonObject(result.stdout.toString()), pkg.name);
   return {
     published: true,
-    name: parsedResult.name,
-    version: parsedResult.version,
-    size: parsedResult.size,
-    unpackedSize: parsedResult.unpackedSize,
+    name: parsedResult?.name ?? pkg.name,
+    version: parsedResult?.version ?? pkg.version,
+    size: parsedResult?.size ?? 0,
+    unpackedSize: parsedResult?.unpackedSize ?? 0,
   };
 }
 
@@ -117,13 +142,13 @@ export async function publishPackageWithPnpm(
       unpackedSize: tabballManifest.dist?.unpackedSize ?? 0,
     };
   } else {
-    const parsedResult: NpmPublishResult = json;
+    const parsedResult = normalizeNpmPublishResult(json, pkg.name);
     return {
       published: true,
-      name: parsedResult.name,
-      version: parsedResult.version,
-      size: parsedResult.size,
-      unpackedSize: parsedResult.unpackedSize,
+      name: parsedResult?.name ?? pkg.name,
+      version: parsedResult?.version ?? pkg.version,
+      size: parsedResult?.size ?? 0,
+      unpackedSize: parsedResult?.unpackedSize ?? 0,
     };
   }
 }


### PR DESCRIPTION
## Problem

The CI `test` job fails on `publish-package.test.ts` (`with npm`) on newer npm versions.

npm 12 changed the shape of `npm publish --json` from a flat object to one keyed by package name:

- Old: `{ id, name, version, size, unpackedSize, ... }`
- New: `{ "pkg-name": { id, name, version, size, unpackedSize, ... } }`

The result parser read the fields off the top level, so `name`/`version`/`size`/`unpackedSize` came back `undefined` with npm 12+, producing incorrect publish results.

## Fix

- Add `normalizeNpmPublishResult()` which unwraps the new keyed format (preferring the entry matching the package name, falling back to the first entry) and passes the legacy flat format through unchanged.
- Apply it to both the npm and pnpm publish paths, with safe fallbacks to the known package name/version.

## Verification

- Confirmed the new format against npm 12's own source (`logTar` emits `{ [pkgContents.name]: tarball }`).
- Ran the publish integration test against a real npm 12 shim -> `with npm` tests pass (previously failed).
- Ran against npm 11 (legacy flat format) -> still pass, no regression.
- Added `normalize-npm-publish-result.test.ts` covering both formats so this is caught regardless of installed npm version.
- Full suite green; lint, format, and build clean.
