### PR TITLE
Fix dependents not bumped for 0.x caret (workspace:^) deps on minor bump

### DIFF
--- a/.chronus/changes/fix-dependent-bump-0x-caret-2026-7-16-11-29-0.md
+++ b/.chronus/changes/fix-dependent-bump-0x-caret-2026-7-16-11-29-0.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: breaking, feature, fix, internal
+changeKind: fix
+packages:
+  - "@chronus/chronus"
+---
+
+Fix dependents not being bumped when a `^`/`workspace:^` dependency on a `0.x` package receives a minor bump. Since `^0.n.x` is locked to the minor (`>=0.n.0 <0.(n+1).0`), a minor bump is breaking and now correctly forces dependents to be released.

--- a/packages/chronus/src/release-plan/assemble-release-plan.test.ts
+++ b/packages/chronus/src/release-plan/assemble-release-plan.test.ts
@@ -135,6 +135,39 @@ describe("Assemble Release Plan", () => {
           newVersion: "1.0.1",
         });
       });
+
+      it("workspace:^ dependency on a 0.x package is bumped when the dependency gets a minor bump (0.x minor is breaking)", () => {
+        const workspace: Package[] = [
+          mkPkg("pkg-a", { version: "0.2.0" }),
+          mkPkg("pkg-b", { dependencies: { "pkg-a": "workspace:^" } }),
+        ];
+        const plan = assembleReleasePlan([mkChange("pkg-a", "minor")], createChronusWorkspace(workspace, baseConfig));
+        expect(plan.actions).toHaveLength(2);
+        expect(plan.actions[0]).toMatchObject({
+          packageName: "pkg-a",
+          oldVersion: "0.2.0",
+          newVersion: "0.3.0",
+        });
+        expect(plan.actions[1]).toMatchObject({
+          packageName: "pkg-b",
+          oldVersion: "1.0.0",
+          newVersion: "1.0.1",
+        });
+      });
+
+      it("workspace:^ dependency on a 0.x package is NOT bumped for a patch bump (still within range)", () => {
+        const workspace: Package[] = [
+          mkPkg("pkg-a", { version: "0.2.0" }),
+          mkPkg("pkg-b", { dependencies: { "pkg-a": "workspace:^" } }),
+        ];
+        const plan = assembleReleasePlan([mkChange("pkg-a", "patch")], createChronusWorkspace(workspace, baseConfig));
+        expect(plan.actions).toHaveLength(1);
+        expect(plan.actions[0]).toMatchObject({
+          packageName: "pkg-a",
+          oldVersion: "0.2.0",
+          newVersion: "0.2.1",
+        });
+      });
     });
 
     describe("prerelease version (x.y.z-foo.n) only increase the n regardless of the change type", () => {

--- a/packages/chronus/src/release-plan/determine-dependents.ts
+++ b/packages/chronus/src/release-plan/determine-dependents.ts
@@ -139,10 +139,13 @@ function willRangeBeValid(release: InternalReleaseAction, versionRange: string) 
   switch (versionRange) {
     case "*":
       return true;
+    // `^` and `~` are the `workspace:^` / `workspace:~` shorthands. Resolve them against the
+    // current version so 0.x semantics are respected (e.g. `^0.1.2` := `>=0.1.2 <0.2.0`), meaning
+    // a minor bump on a 0.x dependency is breaking and must invalidate the range.
     case "^":
-      return release.type === "minor" || release.type === "patch";
+      return semverSatisfies(incrementVersion(release), `^${release.oldVersion}`);
     case "~":
-      return release.type === "patch";
+      return semverSatisfies(incrementVersion(release), `~${release.oldVersion}`);
     default:
       return semverSatisfies(incrementVersion(release), versionRange);
   }


### PR DESCRIPTION
## Problem

`chronus version` no longer bumps a package whose only reason to bump is a `^` / `workspace:^` dependency on a **0.x** package that is receiving a **minor** bump. This is a regression from `1.0.0`.

Concrete repro (from `typespec-azure`): `@azure-tools/azure-http-specs` peer-depends on `@azure-tools/typespec-azure-core` via `workspace:^`. When `typespec-azure-core` is lockstep-bumped `0.70.0 → 0.71.0` (minor), `azure-http-specs` is skipped, even though `^0.70.0` (`>=0.70.0 <0.71.0`) no longer allows `0.71.0`.

## Root cause

`willRangeBeValid` in `determine-dependents.ts` hardcoded caret/tilde semantics without considering the dependency's current version:

```ts
case "^":
  return release.type === "minor" || release.type === "patch"; // wrong for 0.x
```

For a 0.x dependency, `^0.n.x` is locked to the minor, so a minor bump is breaking and must invalidate the range. The 1.0.0 code had a 0.x/peer special-case that was later removed (and `DependencyType` was collapsed to `"prod" | "dev"`).

## Fix

Resolve the `^` / `~` `workspace:` shorthands against the dependency's current version using real semver, so 0.x semantics are respected and ≥1.x behavior is preserved:

```ts
case "^":
  return semverSatisfies(incrementVersion(release), `^${release.oldVersion}`);
case "~":
  return semverSatisfies(incrementVersion(release), `~${release.oldVersion}`);
```

## Tests / verification

- Added regression tests in `assemble-release-plan.test.ts`: a 0.x dep via `workspace:^` with a minor bump forces the dependent to bump; a patch bump does not. Existing 1.x tests still pass.
- `pnpm test` (237 pass), `pnpm build`, and `oxlint` all clean.
- Verified end-to-end against the real `typespec-azure` workspace: fixed build bumps `@azure-tools/azure-http-specs` (`0.1.0-alpha.43 → alpha.44`), while the released `1.3.1` does not.