### PR TITLE
fix: create release PR as draft

### DIFF
--- a/eng/prepare-release-pr.ts
+++ b/eng/prepare-release-pr.ts
@@ -56,6 +56,7 @@ if (stdout.trim() !== "") {
       head: branchName,
       base: "main",
       body: changeStatus,
+      draft: true,
     });
   }
 } else {


### PR DESCRIPTION
Create the release PR as a draft.

The `prepare-release-pr` script now passes `draft: true` when opening the "Release changes" PR, so it is created in draft state instead of being immediately ready for review.
